### PR TITLE
[Feat] 블록 디자인 적용

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 8.1.0(embla-carousel@8.5.2)
       motion:
         specifier: ^12.24.11
-        version: 12.24.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 12.29.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.0
         version: 19.2.3
@@ -512,14 +512,6 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
-
-  '@lottiefiles/dotlottie-react@0.17.13':
-    resolution: {integrity: sha512-Ui8bqFlxqxLqB3G4bE9nsSw05lUn7eiZ24dSi/NVHFjTMAlb/JxdS8xWt1cdF2W1yJPNCeQuze6kkqNC5OMbJg==}
-    peerDependencies:
-      react: ^17 || ^18 || ^19
-
-  '@lottiefiles/dotlottie-web@0.61.0':
-    resolution: {integrity: sha512-1QwcDchh/TXTvP9zXUHA5oJOdhEdUrn6U7gAiQ1AXEUrcK6PTU6v5D3byP76BK56fQjoY2WQ2A4pYDCCvoVRqw==}
 
   '@lottiefiles/dotlottie-react@0.17.13':
     resolution: {integrity: sha512-Ui8bqFlxqxLqB3G4bE9nsSw05lUn7eiZ24dSi/NVHFjTMAlb/JxdS8xWt1cdF2W1yJPNCeQuze6kkqNC5OMbJg==}
@@ -1380,8 +1372,8 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
-  framer-motion@12.24.11:
-    resolution: {integrity: sha512-cNTxTGvFKcY/eQcuGMpG2rb7DOxEFW+A8h5MFhwPqQrn4Jyz9hFhJAlHpngxZIkS0Kk+rZiYmuxNMgO5dGxeYQ==}
+  framer-motion@12.29.2:
+    resolution: {integrity: sha512-lSNRzBJk4wuIy0emYQ/nfZ7eWhqud2umPKw2QAQki6uKhZPKm2hRQHeQoHTG9MIvfobb+A/LbEWPJU794ZUKrg==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -1742,14 +1734,14 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  motion-dom@12.24.11:
-    resolution: {integrity: sha512-DlWOmsXMJrV8lzZyd+LKjG2CXULUs++bkq8GZ2Sr0R0RRhs30K2wtY+LKiTjhmJU3W61HK+rB0GLz6XmPvTA1A==}
+  motion-dom@12.29.2:
+    resolution: {integrity: sha512-/k+NuycVV8pykxyiTCoFzIVLA95Nb1BFIVvfSu9L50/6K6qNeAYtkxXILy/LRutt7AzaYDc2myj0wkCVVYAPPA==}
 
-  motion-utils@12.24.10:
-    resolution: {integrity: sha512-x5TFgkCIP4pPsRLpKoI86jv/q8t8FQOiM/0E8QKBzfMozWHfkKap2gA1hOki+B5g3IsBNpxbUnfOum1+dgvYww==}
+  motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
 
-  motion@12.24.11:
-    resolution: {integrity: sha512-nfon8E7NDNh42QTJHwB9gjnfdGLFLf0eCu0izAJ7qmZ1NFODuVp+n20kfe5r5PEQlJyONjI0znSKm7QN8szQAQ==}
+  motion@12.29.2:
+    resolution: {integrity: sha512-jMpHdAzEDF1QQ055cB+1lOBLdJ6ialVWl6QQzpJI2OvmHequ7zFVHM2mx0HNAy+Tu4omUlApfC+4vnkX0geEOg==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -3434,10 +3426,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  framer-motion@12.24.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  framer-motion@12.29.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      motion-dom: 12.24.11
-      motion-utils: 12.24.10
+      motion-dom: 12.29.2
+      motion-utils: 12.29.2
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.3
@@ -3736,15 +3728,15 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  motion-dom@12.24.11:
+  motion-dom@12.29.2:
     dependencies:
-      motion-utils: 12.24.10
+      motion-utils: 12.29.2
 
-  motion-utils@12.24.10: {}
+  motion-utils@12.29.2: {}
 
-  motion@12.24.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  motion@12.29.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      framer-motion: 12.24.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      framer-motion: 12.29.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.3

--- a/src/feature/block/blockBuild/components/BlockEditor.tsx
+++ b/src/feature/block/blockBuild/components/BlockEditor.tsx
@@ -44,9 +44,7 @@ const BlockEditor = () => {
         {activeDrag?.type === 'blockSidebar' && <BlockItem item={activeDrag.block} />}
         {/* {activeDrag?.type === 'blockEditor' && (
           // TODO: 여기에 드래그하면서 보여지는 퍼즐 컴포넌트
-          <div
-            className="rounded-xl p-4 shadow-xl opacity-90"
-            style={{ width: activeDrag.w, height: activeDrag.h }}></div>
+          // Use getBoundingBox(activeDrag.points) for width/height
         )} */}
       </DragOverlay>
     </DndContext>

--- a/src/feature/block/blockBuild/components/BlockEditor.tsx
+++ b/src/feature/block/blockBuild/components/BlockEditor.tsx
@@ -44,7 +44,6 @@ const BlockEditor = () => {
         {activeDrag?.type === 'blockSidebar' && <BlockItem item={activeDrag.block} />}
         {/* {activeDrag?.type === 'blockEditor' && (
           // TODO: 여기에 드래그하면서 보여지는 퍼즐 컴포넌트
-          // Use getBoundingBox(activeDrag.points) for width/height
         )} */}
       </DragOverlay>
     </DndContext>

--- a/src/feature/block/blockBuild/components/side/BlockItem.tsx
+++ b/src/feature/block/blockBuild/components/side/BlockItem.tsx
@@ -23,7 +23,7 @@ const BlockItem = ({ item }: BlockItemProps) => {
       {...listeners}
       {...attributes}
       className={clsx(
-        'relative w-full h-[84px] rounded-[10px] border border-gray-200 bg-base-color-6 flex items-center gap-3 p-3',
+        'relative w-full h-21 rounded-[10px] border border-gray-200 bg-base-color-6 flex items-center gap-3 p-3',
         'cursor-grab active:cursor-grabbing transition-shadow hover:shadow-md',
         isDragging && 'opacity-0',
       )}>
@@ -47,9 +47,7 @@ const BlockItem = ({ item }: BlockItemProps) => {
       {/* 텍스트 정보 */}
       <div className="flex flex-col items-start text-left">
         {/* 카테고리 */}
-        <span
-          className={blockItemStyles.smallText}
-          style={{ color: categoryColor[item.category as keyof typeof categoryColor] }}>
+        <span className={clsx(blockItemStyles.smallText, categoryColor[item.category as keyof typeof categoryColor])}>
           {item.category}
         </span>
 

--- a/src/feature/block/blockBuild/components/side/block-styles.ts
+++ b/src/feature/block/blockBuild/components/side/block-styles.ts
@@ -2,10 +2,11 @@ import clsx from 'clsx';
 
 // 카테고리별 색상 매핑
 export const categoryColor = {
-  숙소: '#FF459C',
-  식당: '#FF5353',
-  카페: '#E0B795',
-  관광: '#5B8DEF',
+  숙소: 'text-[#FF459C]',
+  식당: 'text-[#FF5353]',
+  카페: 'text-[#E0B795]',
+  관광: 'text-[#5B8DEF]',
+  기타: 'text-[#3C4EF4]',
   // TODO: 색상 추가 필요
 };
 

--- a/src/feature/block/blockBuild/components/ui/BlockGhost.tsx
+++ b/src/feature/block/blockBuild/components/ui/BlockGhost.tsx
@@ -1,26 +1,19 @@
 import clsx from 'clsx';
 import type { DockHintState } from '../../types/drag';
+import { useBlockPath } from '@/shared/components/Block/blockShape';
 
 export default function BlockGhost({ hint }: { hint: DockHintState }) {
+  const pathD = useBlockPath(hint?.points || [], hint?.connectors || []);
+
   if (!hint?.visible) return null;
 
   return (
-    <div
-      className="absolute z-content pointer-events-none"
-      style={{ left: hint.x, top: hint.y, width: hint.w, height: hint.h }}>
-      {/* TODO: 퍼즐 가까이 다가갔을 때 힌트 컴포넌트 여기다가 추가 */}
-      {/* 지금은 임시 */}
-      <div className={clsx('w-full h-full rounded-xl border-2 border-dashed border-blue-500 bg-blue-200/20')} />
-
-      {/* TODO: 오른쪽 방향 들어갈떄 컴포넌트 추가 */}
-      {/* edgeIndex: 0=top, 1=right, 2=bottom, 3=left */}
-      {hint.edgeIndex === 1 && (
-        <div className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 w-6 h-6 rounded-full border-2 border-dashed border-blue-500 bg-blue-200/20" />
-      )}
-      {/* TODO: 아래쪽 방향 들어갈떄 컴포넌트 추가 */}
-      {hint.edgeIndex === 2 && (
-        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 w-6 h-6 rounded-full border-2 border-dashed border-blue-500 bg-blue-200/20" />
-      )}
+    <div className="absolute z-content pointer-events-none" style={{ left: hint.x, top: hint.y }}>
+      <svg
+        className={clsx('absolute top-0 left-0 overflow-visible opacity-30', hint.color || 'text-blue-500')}
+        style={{ pointerEvents: 'none' }}>
+        <path d={pathD} fill="currentColor" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
+      </svg>
     </div>
   );
 }

--- a/src/feature/block/blockBuild/components/ui/BlockGhost.tsx
+++ b/src/feature/block/blockBuild/components/ui/BlockGhost.tsx
@@ -13,11 +13,12 @@ export default function BlockGhost({ hint }: { hint: DockHintState }) {
       <div className={clsx('w-full h-full rounded-xl border-2 border-dashed border-blue-500 bg-blue-200/20')} />
 
       {/* TODO: 오른쪽 방향 들어갈떄 컴포넌트 추가 */}
-      {hint.side === 'right' && (
+      {/* edgeIndex: 0=top, 1=right, 2=bottom, 3=left */}
+      {hint.edgeIndex === 1 && (
         <div className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 w-6 h-6 rounded-full border-2 border-dashed border-blue-500 bg-blue-200/20" />
       )}
       {/* TODO: 아래쪽 방향 들어갈떄 컴포넌트 추가 */}
-      {hint.side === 'bottom' && (
+      {hint.edgeIndex === 2 && (
         <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 w-6 h-6 rounded-full border-2 border-dashed border-blue-500 bg-blue-200/20" />
       )}
     </div>

--- a/src/feature/block/blockBuild/components/ui/BlockStartNode.tsx
+++ b/src/feature/block/blockBuild/components/ui/BlockStartNode.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import type { Block } from '../../types/block';
+import { getBoundingBox } from '@/shared/components/Block/blockShape';
 import BlockStart from './BlockStart';
 
 type BlockStartNodeProps = {
@@ -7,14 +8,16 @@ type BlockStartNodeProps = {
 };
 
 export default function BlockStartNode({ block }: BlockStartNodeProps) {
+  const { w, h } = getBoundingBox(block.points);
+
   return (
     <div
       className={clsx('absolute select-none z-content')}
       style={{
         left: block.x,
         top: block.y,
-        width: block.w,
-        height: block.h,
+        width: w,
+        height: h,
       }}>
       <BlockStart className="w-full h-full" />
     </div>

--- a/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
+++ b/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
@@ -1,7 +1,9 @@
 import { useDraggable } from '@dnd-kit/core';
-import type { Block } from '../../types/block';
+import type { Block as BlockData } from '../../types/block';
+import { Block } from '@/shared/components/Block/Block';
+import { createRectPoints } from '@/shared/components/Block/blockShape';
 
-export default function PuzzleBlock({ block, canDrag }: { block: Block; canDrag: boolean }) {
+export default function PuzzleBlock({ block, canDrag }: { block: BlockData; canDrag: boolean }) {
   const { setNodeRef, listeners, attributes, transform, isDragging } = useDraggable({
     id: `editor:${block.blockId}`,
     data: {
@@ -30,17 +32,18 @@ export default function PuzzleBlock({ block, canDrag }: { block: Block; canDrag:
       style={{
         left: block.x,
         top: block.y,
-        width: block.w,
-        height: block.h,
         transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
       }}>
-      {/* TODO: 여기서 퍼즐 SVG 컴포넌트로 교체 */}
-      <div className="w-full h-full rounded-xl bg-primary-color text-base-color-6 p-4">
-        <div className="font-semibold">{block.name}</div>
-        <div className="text-xs opacity-90">
-          {block.category} · {block.duration}
-        </div>
-      </div>
+      <Block
+        title={block.name}
+        category={block.category}
+        duration={block.duration}
+        points={createRectPoints(block.w, block.h)}
+        connections={[
+          { edgeIndex: 0, type: 'plug', align: 'center' },
+          { edgeIndex: 2, type: 'socket', align: 'center' },
+        ]}
+      />
     </div>
   );
 }

--- a/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
+++ b/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
@@ -12,6 +12,7 @@ export default function PuzzleBlock({ block, canDrag }: { block: BlockData; canD
       startY: block.y,
       points: block.points,
       connectors: block.connectors,
+      color: block.color,
     },
     disabled: !canDrag,
   });
@@ -38,6 +39,7 @@ export default function PuzzleBlock({ block, canDrag }: { block: BlockData; canD
         duration={block.duration}
         points={block.points}
         connections={block.connectors}
+        color={block.color}
       />
     </div>
   );

--- a/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
+++ b/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
@@ -1,7 +1,6 @@
 import { useDraggable } from '@dnd-kit/core';
 import type { Block as BlockData } from '../../types/block';
 import { Block } from '@/shared/components/Block/Block';
-import { createRectPoints } from '@/shared/components/Block/blockShape';
 
 export default function PuzzleBlock({ block, canDrag }: { block: BlockData; canDrag: boolean }) {
   const { setNodeRef, listeners, attributes, transform, isDragging } = useDraggable({
@@ -11,8 +10,7 @@ export default function PuzzleBlock({ block, canDrag }: { block: BlockData; canD
       blockId: block.blockId,
       startX: block.x,
       startY: block.y,
-      w: block.w,
-      h: block.h,
+      points: block.points,
       connectors: block.connectors,
     },
     disabled: !canDrag,
@@ -38,11 +36,8 @@ export default function PuzzleBlock({ block, canDrag }: { block: BlockData; canD
         title={block.name}
         category={block.category}
         duration={block.duration}
-        points={createRectPoints(block.w, block.h)}
-        connections={[
-          { edgeIndex: 0, type: 'plug', align: 'center' },
-          { edgeIndex: 2, type: 'socket', align: 'center' },
-        ]}
+        points={block.points}
+        connections={block.connectors}
       />
     </div>
   );

--- a/src/feature/block/blockBuild/hooks/useBlockDrag.ts
+++ b/src/feature/block/blockBuild/hooks/useBlockDrag.ts
@@ -13,10 +13,7 @@ const DEFAULT_BLOCK = { w: 125, h: 125 };
 const GRID = 40;
 
 const START_ID = 0;
-
 const SNAP_THRESHOLD = 67;
-const CONNECTOR_OFFSET = 0;
-const ALLOW_BOTTOM = true;
 
 interface UseBlockDragParams {
   puzzleBlocks: Block[];
@@ -97,8 +94,6 @@ export const useBlockDrag = ({ puzzleBlocks, currentDay, updateBlocksByDay, remo
         candidate,
         tail,
         threshold: SNAP_THRESHOLD,
-        connectorOffset: CONNECTOR_OFFSET,
-        allowBottom: ALLOW_BOTTOM,
       });
 
       setDockHint(buildDockHint({ candidate, decision }));
@@ -144,8 +139,6 @@ export const useBlockDrag = ({ puzzleBlocks, currentDay, updateBlocksByDay, remo
         candidate,
         tail,
         threshold: SNAP_THRESHOLD,
-        connectorOffset: CONNECTOR_OFFSET,
-        allowBottom: ALLOW_BOTTOM,
       });
 
       // 1) Sidebar -> Board 생성

--- a/src/feature/block/blockBuild/hooks/useBlockDrag.ts
+++ b/src/feature/block/blockBuild/hooks/useBlockDrag.ts
@@ -9,7 +9,7 @@ import { calcCandidate } from '../utils/boardCandidate';
 import { buildDockHint, computeSnapDecision } from '../utils/dockHint';
 
 // TODO: 여기서 퍼즐 시간 단위로 교체
-const DEFAULT_BLOCK = { w: 260, h: 64 };
+const DEFAULT_BLOCK = { w: 125, h: 125 };
 const GRID = 40;
 
 const START_ID = 0;

--- a/src/feature/block/blockBuild/hooks/useBlockDrag.ts
+++ b/src/feature/block/blockBuild/hooks/useBlockDrag.ts
@@ -49,11 +49,10 @@ export const useBlockDrag = ({ puzzleBlocks, currentDay, updateBlocksByDay, remo
 
       if (type === 'blockEditor') {
         const blockId = e.active.data.current?.blockId as number;
-        const w = e.active.data.current?.w as number;
-        const h = e.active.data.current?.h as number;
+        const points = e.active.data.current?.points as Block['points'];
         const connectors = e.active.data.current?.connectors as Block['connectors'];
-        if (blockId && w && h) {
-          setActiveDrag({ type: 'blockEditor', blockId, w, h, connectors });
+        if (blockId && points && connectors) {
+          setActiveDrag({ type: 'blockEditor', blockId, points, connectors });
         }
 
         if (blockId !== null) {

--- a/src/feature/block/blockBuild/hooks/useBlockDrag.ts
+++ b/src/feature/block/blockBuild/hooks/useBlockDrag.ts
@@ -51,8 +51,9 @@ export const useBlockDrag = ({ puzzleBlocks, currentDay, updateBlocksByDay, remo
         const blockId = e.active.data.current?.blockId as number;
         const points = e.active.data.current?.points as Block['points'];
         const connectors = e.active.data.current?.connectors as Block['connectors'];
+        const color = e.active.data.current?.color as Block['color'];
         if (blockId && points && connectors) {
-          setActiveDrag({ type: 'blockEditor', blockId, points, connectors });
+          setActiveDrag({ type: 'blockEditor', blockId, points, connectors, color });
         }
 
         if (blockId !== null) {

--- a/src/feature/block/blockBuild/types/block.ts
+++ b/src/feature/block/blockBuild/types/block.ts
@@ -18,6 +18,7 @@ export type Block = {
   category: CategoryType;
   duration: string;
   imageUrl?: string;
+  color?: string;
   // 보드 위치
   x: number;
   y: number;

--- a/src/feature/block/blockBuild/types/block.ts
+++ b/src/feature/block/blockBuild/types/block.ts
@@ -1,7 +1,6 @@
-export type CategoryType = '숙소' | '식당' | '카페' | '관광' | '문화' | '액티비티' | '투어' | '기타';
+import type { Connector, Point } from '@/shared/components/Block/blockShape';
 
-// 연결 선 방향
-export type ConnectorLine = 'top' | 'bottom' | 'left' | 'right';
+export type CategoryType = '숙소' | '식당' | '카페' | '관광' | '문화' | '액티비티' | '투어' | '기타';
 
 // 샘플 사이드바 데이터 타입
 export type SidebarBlock = {
@@ -22,13 +21,10 @@ export type Block = {
   // 보드 위치
   x: number;
   y: number;
-  w: number;
-  h: number;
-  // 커넥터 선
-  connectors?: {
-    input: ConnectorLine | null;
-    output: ConnectorLine | null;
-  } | null;
+  // 블록 모양 (폴리곤 포인트)
+  points: Point[];
+  // 커넥터 설정
+  connectors: Connector[];
   // 연결된 블록 ID
   connectedTo?: number | null;
   connectedFrom?: number | null;

--- a/src/feature/block/blockBuild/types/drag.ts
+++ b/src/feature/block/blockBuild/types/drag.ts
@@ -1,5 +1,4 @@
 import type { Block, SidebarBlock } from './block';
-import type { DockSide } from '../utils/snapToTail';
 
 export type DragType = 'blockSidebar' | 'blockEditor';
 
@@ -13,7 +12,7 @@ export type ActiveDrag =
 export type DockHintState = {
   visible: boolean;
   targetId?: number;
-  side: DockSide;
+  edgeIndex: number;
   x: number;
   y: number;
   w: number;

--- a/src/feature/block/blockBuild/types/drag.ts
+++ b/src/feature/block/blockBuild/types/drag.ts
@@ -5,7 +5,7 @@ export type DragType = 'blockSidebar' | 'blockEditor';
 // 현재 드래그 중인 블록 정보
 export type ActiveDrag =
   | { type: 'blockSidebar'; block: SidebarBlock }
-  | { type: 'blockEditor'; blockId: number; w: number; h: number; connectors: Block['connectors'] }
+  | { type: 'blockEditor'; blockId: number; points: Block['points']; connectors: Block['connectors'] }
   | null;
 
 // 근처 블록 힌트 상태

--- a/src/feature/block/blockBuild/types/drag.ts
+++ b/src/feature/block/blockBuild/types/drag.ts
@@ -5,7 +5,13 @@ export type DragType = 'blockSidebar' | 'blockEditor';
 // 현재 드래그 중인 블록 정보
 export type ActiveDrag =
   | { type: 'blockSidebar'; block: SidebarBlock }
-  | { type: 'blockEditor'; blockId: number; points: Block['points']; connectors: Block['connectors'] }
+  | {
+      type: 'blockEditor';
+      blockId: number;
+      points: Block['points'];
+      connectors: Block['connectors'];
+      color: Block['color'];
+    }
   | null;
 
 // 근처 블록 힌트 상태
@@ -15,6 +21,7 @@ export type DockHintState = {
   edgeIndex: number;
   x: number;
   y: number;
-  w: number;
-  h: number;
+  color: Block['color'];
+  points: Block['points'];
+  connectors: Block['connectors'];
 } | null;

--- a/src/feature/block/blockBuild/utils/boardCandidate.ts
+++ b/src/feature/block/blockBuild/utils/boardCandidate.ts
@@ -1,8 +1,23 @@
 import type { DragMoveEvent, DragEndEvent } from '@dnd-kit/core';
 import type { DragType } from '../types/drag';
+import type { Connector, Point } from '@/shared/components/Block/blockShape';
+import { createRectPoints, getBoundingBox } from '@/shared/components/Block/blockShape';
 import { calcBoardPointFromActiveRect, clampInBoard, getActiveRect } from './board';
 
-export type Candidate = { x: number; y: number; w: number; h: number };
+export type Candidate = {
+  x: number;
+  y: number;
+  points: Point[];
+  connectors: Connector[];
+};
+
+// 기본 커넥터 설정 (사각형 블록용)
+const DEFAULT_CONNECTORS: Connector[] = [
+  { type: 'plug', edgeIndex: 0, align: 'start' },
+  { type: 'socket', edgeIndex: 1, align: 'start' },
+  { type: 'socket', edgeIndex: 2, align: 'start' },
+  { type: 'plug', edgeIndex: 3, align: 'end' },
+];
 
 export function calcCandidate(params: {
   e: DragMoveEvent | DragEndEvent;
@@ -20,18 +35,20 @@ export function calcCandidate(params: {
 
     const w = defaultSize.w;
     const h = defaultSize.h;
+    const points = createRectPoints(w, h);
     const { x, y } = calcBoardPointFromActiveRect({ boardEl, activeRect, w, h, grid });
-    return { x, y, w, h };
+    return { x, y, points, connectors: DEFAULT_CONNECTORS };
   }
 
   // Editor 블록 이동 중일 때 스냅 프리뷰
   if (type === 'blockEditor') {
     const startX = e.active.data.current?.startX as number | undefined;
     const startY = e.active.data.current?.startY as number | undefined;
-    const w = e.active.data.current?.w as number | undefined;
-    const h = e.active.data.current?.h as number | undefined;
-    if (startX == null || startY == null || !w || !h) return null;
+    const points = e.active.data.current?.points as Point[] | undefined;
+    const connectors = e.active.data.current?.connectors as Connector[] | undefined;
+    if (startX == null || startY == null || !points || !connectors) return null;
 
+    const { w, h } = getBoundingBox(points);
     const { x, y } = clampInBoard({
       boardEl,
       x: startX + e.delta.x,
@@ -40,7 +57,7 @@ export function calcCandidate(params: {
       h,
       grid,
     });
-    return { x, y, w, h };
+    return { x, y, points, connectors };
   }
 
   return null;

--- a/src/feature/block/blockBuild/utils/boardCandidate.ts
+++ b/src/feature/block/blockBuild/utils/boardCandidate.ts
@@ -3,12 +3,15 @@ import type { DragType } from '../types/drag';
 import type { Connector, Point } from '@/shared/components/Block/blockShape';
 import { createRectPoints, getBoundingBox } from '@/shared/components/Block/blockShape';
 import { calcBoardPointFromActiveRect, clampInBoard, getActiveRect } from './board';
+import { categoryColor } from '../components/side/block-styles';
+import { type CategoryType } from '../types/block';
 
 export type Candidate = {
   x: number;
   y: number;
   points: Point[];
   connectors: Connector[];
+  color?: string;
 };
 
 // 기본 커넥터 설정 (사각형 블록용)
@@ -37,7 +40,11 @@ export function calcCandidate(params: {
     const h = defaultSize.h;
     const points = createRectPoints(w, h);
     const { x, y } = calcBoardPointFromActiveRect({ boardEl, activeRect, w, h, grid });
-    return { x, y, points, connectors: DEFAULT_CONNECTORS };
+
+    const category = e.active.data.current?.item?.category as CategoryType | undefined;
+    const color = category ? categoryColor[category as keyof typeof categoryColor] : undefined;
+
+    return { x, y, points, connectors: DEFAULT_CONNECTORS, color };
   }
 
   // Editor 블록 이동 중일 때 스냅 프리뷰
@@ -46,6 +53,7 @@ export function calcCandidate(params: {
     const startY = e.active.data.current?.startY as number | undefined;
     const points = e.active.data.current?.points as Point[] | undefined;
     const connectors = e.active.data.current?.connectors as Connector[] | undefined;
+    const color = e.active.data.current?.color as string | undefined;
     if (startX == null || startY == null || !points || !connectors) return null;
 
     const { w, h } = getBoundingBox(points);
@@ -57,7 +65,7 @@ export function calcCandidate(params: {
       h,
       grid,
     });
-    return { x, y, points, connectors };
+    return { x, y, points, connectors, color };
   }
 
   return null;

--- a/src/feature/block/blockBuild/utils/commit.ts
+++ b/src/feature/block/blockBuild/utils/commit.ts
@@ -45,9 +45,8 @@ export function commitSidebarDrop(params: {
     imageUrl: tpl.imageUrl,
     x: decision.x, // canSnap이면 스냅 위치, 아니면 candidate 위치
     y: decision.y,
-    w: candidate.w,
-    h: candidate.h,
-    connectors: { input: null, output: null },
+    points: candidate.points,
+    connectors: candidate.connectors,
     connectedTo: null,
     connectedFrom: null,
   };

--- a/src/feature/block/blockBuild/utils/commit.ts
+++ b/src/feature/block/blockBuild/utils/commit.ts
@@ -43,6 +43,7 @@ export function commitSidebarDrop(params: {
     category: tpl.category,
     duration: tpl.duration,
     imageUrl: tpl.imageUrl,
+    color: candidate.color,
     x: decision.x, // canSnap이면 스냅 위치, 아니면 candidate 위치
     y: decision.y,
     points: candidate.points,

--- a/src/feature/block/blockBuild/utils/dockHint.ts
+++ b/src/feature/block/blockBuild/utils/dockHint.ts
@@ -1,14 +1,24 @@
 import type { Block } from '../types/block';
 import type { DockHintState } from '../types/drag';
 import type { Candidate } from './boardCandidate';
-import { snapToTail, type DockSide, type TailSnapResult } from './snapToTail';
+import { snapToTail, type TailSnapResult } from './snapToTail';
+import { createRectPoints, type Connector } from '@/shared/components/Block/blockShape';
+
+// 기본 커넥터 설정 (사각형 블록용)
+// edgeIndex: 0=top, 1=right, 2=bottom, 3=left
+const DEFAULT_CONNECTORS: Connector[] = [
+  { type: 'plug', edgeIndex: 0, align: 'center' },
+  { type: 'socket', edgeIndex: 1, align: 'end' },
+  { type: 'socket', edgeIndex: 2, align: 'start' },
+  { type: 'plug', edgeIndex: 3, align: 'end' },
+];
 
 // 스냅 결정 타입
 export type SnapDecision = {
   canSnap: boolean;
   x: number;
   y: number;
-  side: DockSide | null;
+  edgeIndex: number | null;
   targetId: number | null;
 };
 
@@ -17,45 +27,48 @@ export function computeSnapDecision(params: {
   candidate: Candidate;
   tail: Block | null;
   threshold: number;
-  connectorOffset: number;
-  allowBottom: boolean;
 }): SnapDecision {
-  const { candidate, tail, threshold, connectorOffset, allowBottom } = params;
+  const { candidate, tail, threshold } = params;
 
   if (!tail) {
-    return { canSnap: false, x: candidate.x, y: candidate.y, side: null, targetId: null };
+    return { canSnap: false, x: candidate.x, y: candidate.y, edgeIndex: null, targetId: null };
   }
-
-  // start 블록은 아래 방향(bottom) 도킹 x
-  const isStart = tail.blockId === 0;
-  const effectiveAllowBottom = allowBottom && !isStart;
 
   // 꼬리 스냅 결과 계산
   const snap: TailSnapResult = snapToTail({
-    drag: candidate,
-    tail,
+    drag: {
+      x: candidate.x,
+      y: candidate.y,
+      points: createRectPoints(candidate.w, candidate.h),
+      connectors: DEFAULT_CONNECTORS,
+    },
+    tail: {
+      blockId: tail.blockId,
+      x: tail.x,
+      y: tail.y,
+      points: createRectPoints(tail.w, tail.h),
+      connectors: DEFAULT_CONNECTORS,
+    },
     threshold,
-    connectorOffset,
-    allowBottom: effectiveAllowBottom,
   });
 
-  if (!snap.canSnap || !snap.side) {
-    return { canSnap: false, x: candidate.x, y: candidate.y, side: null, targetId: null };
+  if (!snap.canSnap || snap.edgeIndex == null) {
+    return { canSnap: false, x: candidate.x, y: candidate.y, edgeIndex: null, targetId: null };
   }
 
-  return { canSnap: true, x: snap.x, y: snap.y, side: snap.side, targetId: tail.blockId };
+  return { canSnap: true, x: snap.x, y: snap.y, edgeIndex: snap.edgeIndex, targetId: tail.blockId };
 }
 
 // 근처 블록 힌트 빌드
 export function buildDockHint(params: { candidate: Candidate; decision: SnapDecision }): DockHintState {
   const { candidate, decision } = params;
 
-  if (!decision.canSnap || !decision.side || decision.targetId == null) return null;
+  if (!decision.canSnap || decision.edgeIndex == null || decision.targetId == null) return null;
 
   return {
     visible: true,
     targetId: decision.targetId,
-    side: decision.side,
+    edgeIndex: decision.edgeIndex,
     x: decision.x,
     y: decision.y,
     w: candidate.w,

--- a/src/feature/block/blockBuild/utils/dockHint.ts
+++ b/src/feature/block/blockBuild/utils/dockHint.ts
@@ -2,16 +2,7 @@ import type { Block } from '../types/block';
 import type { DockHintState } from '../types/drag';
 import type { Candidate } from './boardCandidate';
 import { snapToTail, type TailSnapResult } from './snapToTail';
-import { createRectPoints, type Connector } from '@/shared/components/Block/blockShape';
-
-// 기본 커넥터 설정 (사각형 블록용)
-// edgeIndex: 0=top, 1=right, 2=bottom, 3=left
-const DEFAULT_CONNECTORS: Connector[] = [
-  { type: 'plug', edgeIndex: 0, align: 'center' },
-  { type: 'socket', edgeIndex: 1, align: 'end' },
-  { type: 'socket', edgeIndex: 2, align: 'start' },
-  { type: 'plug', edgeIndex: 3, align: 'end' },
-];
+import { getBoundingBox } from '@/shared/components/Block/blockShape';
 
 // 스냅 결정 타입
 export type SnapDecision = {
@@ -39,15 +30,15 @@ export function computeSnapDecision(params: {
     drag: {
       x: candidate.x,
       y: candidate.y,
-      points: createRectPoints(candidate.w, candidate.h),
-      connectors: DEFAULT_CONNECTORS,
+      points: candidate.points,
+      connectors: candidate.connectors,
     },
     tail: {
       blockId: tail.blockId,
       x: tail.x,
       y: tail.y,
-      points: createRectPoints(tail.w, tail.h),
-      connectors: DEFAULT_CONNECTORS,
+      points: tail.points,
+      connectors: tail.connectors,
     },
     threshold,
   });
@@ -65,13 +56,15 @@ export function buildDockHint(params: { candidate: Candidate; decision: SnapDeci
 
   if (!decision.canSnap || decision.edgeIndex == null || decision.targetId == null) return null;
 
+  const { w, h } = getBoundingBox(candidate.points);
+
   return {
     visible: true,
     targetId: decision.targetId,
     edgeIndex: decision.edgeIndex,
     x: decision.x,
     y: decision.y,
-    w: candidate.w,
-    h: candidate.h,
+    w,
+    h,
   };
 }

--- a/src/feature/block/blockBuild/utils/dockHint.ts
+++ b/src/feature/block/blockBuild/utils/dockHint.ts
@@ -2,7 +2,6 @@ import type { Block } from '../types/block';
 import type { DockHintState } from '../types/drag';
 import type { Candidate } from './boardCandidate';
 import { snapToTail, type TailSnapResult } from './snapToTail';
-import { getBoundingBox } from '@/shared/components/Block/blockShape';
 
 // 스냅 결정 타입
 export type SnapDecision = {
@@ -56,15 +55,14 @@ export function buildDockHint(params: { candidate: Candidate; decision: SnapDeci
 
   if (!decision.canSnap || decision.edgeIndex == null || decision.targetId == null) return null;
 
-  const { w, h } = getBoundingBox(candidate.points);
-
   return {
     visible: true,
     targetId: decision.targetId,
     edgeIndex: decision.edgeIndex,
     x: decision.x,
     y: decision.y,
-    w,
-    h,
+    color: candidate.color,
+    points: candidate.points,
+    connectors: candidate.connectors,
   };
 }

--- a/src/feature/block/blockBuild/utils/snapToTail.ts
+++ b/src/feature/block/blockBuild/utils/snapToTail.ts
@@ -1,4 +1,9 @@
-import { type Point, getConnectorCenter } from '@/shared/components/Block/blockShape';
+import {
+  type Point,
+  getConnectorCenter,
+  getEdgeDirection,
+  areOppositeDirections,
+} from '@/shared/components/Block/blockShape';
 import type { Block } from '../types/block';
 
 export type TailSnapResult = {
@@ -50,6 +55,11 @@ export function snapToTail(params: {
   // 각 socket-plug 쌍에 대해 거리 계산
   for (const socket of tailSockets) {
     for (const plug of dragPlugs) {
+      // 엣지 방향이 서로 반대인지 확인
+      const socketDir = getEdgeDirection(tail.points, socket.edgeIndex);
+      const plugDir = getEdgeDirection(drag.points, plug.edgeIndex);
+      if (!socketDir || !plugDir || !areOppositeDirections(socketDir, plugDir)) continue;
+
       // tail 기준 socket 중심점 (절대 좌표)
       const socketLocal = getConnectorCenter(tail.points, socket, tabWidth);
       if (!socketLocal) continue;

--- a/src/feature/block/blockBuild/utils/snapToTail.ts
+++ b/src/feature/block/blockBuild/utils/snapToTail.ts
@@ -1,66 +1,95 @@
-export type DockSide = 'right' | 'bottom';
+import { type Point, type Connector, getConnectorCenter } from '@/shared/components/Block/blockShape';
 
 export type TailSnapResult = {
   canSnap: boolean;
-  side: DockSide | null;
+  edgeIndex: number | null; // 스냅될 edge 인덱스
   x: number;
   y: number;
   targetId: number | null; // 스냅될 블록 아이디
 };
 
 // 피타고라스 (두 점 사이의 거리 계산)
-const dist = (a: { x: number; y: number }, b: { x: number; y: number }) => {
+const dist = (a: Point, b: Point) => {
   const dx = a.x - b.x;
   const dy = a.y - b.y;
   return Math.sqrt(dx * dx + dy * dy);
 };
 
-// 퍼즐 홈에 들어갈 기준점 계산 (tail의 홈 기준점) -> 퍼즐의 아래, 오른쪽 중심 기준점
-const holePoint = (block: { x: number; y: number; w: number; h: number }, side: DockSide) => {
-  if (side === 'right') return { x: block.x + block.w, y: block.y + block.h / 2 };
-  return { x: block.x + block.w / 2, y: block.y + block.h };
-};
+export interface SnapBlock {
+  blockId: number;
+  x: number;
+  y: number;
+  points: Point[];
+  connectors: Connector[];
+}
 
-// 퍼즐 탭에 들어갈 기준점 계산 (tail의 홈에 들어갈 "드래그 블럭의 탭" 기준점) -> 퍼즐의 위, 왼쪽 중심 기준점
-const tabPoint = (block: { x: number; y: number; w: number; h: number }, side: DockSide) => {
-  if (side === 'right') return { x: block.x, y: block.y + block.h / 2 };
-  return { x: block.x + block.w / 2, y: block.y };
-};
+interface SnapCandidate {
+  x: number;
+  y: number;
+  points: Point[];
+  connectors: Connector[];
+}
 
-// 꼬리 스냅 결과 계산 (가장 가까운 홈과 탭 사이의 거리 계산) -> 홈과 탭 사이의 거리가 가장 가까운 쪽을 반환
+const DEFAULT_TAB_WIDTH = 42;
+
+/**
+ * 드래그 중인 블록이 tail 블록에 스냅될 수 있는지 계산
+ * tail의 socket과 drag의 plug를 매칭하여 가장 가까운 연결점을 찾음
+ */
 export function snapToTail(params: {
-  drag: { x: number; y: number; w: number; h: number };
-  tail: { blockId: number; x: number; y: number; w: number; h: number };
+  drag: SnapCandidate;
+  tail: SnapBlock;
   threshold?: number;
-  connectorOffset?: number;
-  allowBottom?: boolean;
+  tabWidth?: number;
 }): TailSnapResult {
-  const { drag, tail, threshold = 30, connectorOffset = 0, allowBottom = false } = params;
+  const { drag, tail, threshold = 30, tabWidth = DEFAULT_TAB_WIDTH } = params;
 
-  const candidates: DockSide[] = allowBottom ? ['right', 'bottom'] : ['right'];
+  // tail의 모든 socket 찾기
+  const tailSockets = tail.connectors.filter((c) => c.type === 'socket');
+  // drag의 모든 plug 찾기
+  const dragPlugs = drag.connectors.filter((c) => c.type === 'plug');
 
-  let best: { side: DockSide; d: number; x: number; y: number } | null = null;
-
-  for (const side of candidates) {
-    const hp = holePoint(tail, side);
-    const tp = tabPoint(drag, side);
-    const d = dist(hp, tp);
-    if (d > threshold) continue;
-
-    let x = drag.x;
-    let y = drag.y;
-
-    if (side === 'right') {
-      x = tail.x + tail.w - connectorOffset;
-      y = tail.y + tail.h / 2 - drag.h / 2;
-    } else {
-      x = tail.x + tail.w / 2 - drag.w / 2;
-      y = tail.y + tail.h - connectorOffset;
-    }
-
-    if (!best || d < best.d) best = { side, d, x, y };
+  if (tailSockets.length === 0 || dragPlugs.length === 0) {
+    return { canSnap: false, edgeIndex: null, x: drag.x, y: drag.y, targetId: null };
   }
 
-  if (!best) return { canSnap: false, side: null, x: drag.x, y: drag.y, targetId: null };
-  return { canSnap: true, side: best.side, x: best.x, y: best.y, targetId: tail.blockId };
+  let best: { edgeIndex: number; d: number; x: number; y: number } | null = null;
+
+  // 각 socket-plug 쌍에 대해 거리 계산
+  for (const socket of tailSockets) {
+    for (const plug of dragPlugs) {
+      // tail 기준 socket 중심점 (절대 좌표)
+      const socketLocal = getConnectorCenter(tail.points, socket, tabWidth);
+      if (!socketLocal) continue;
+      const socketCenter = { x: tail.x + socketLocal.x, y: tail.y + socketLocal.y };
+
+      // drag 기준 plug 중심점 (절대 좌표)
+      const plugLocal = getConnectorCenter(drag.points, plug, tabWidth);
+      if (!plugLocal) continue;
+      const plugCenter = { x: drag.x + plugLocal.x, y: drag.y + plugLocal.y };
+
+      const d = dist(socketCenter, plugCenter);
+      if (d > threshold) continue;
+
+      // 스냅 위치 계산: plug 중심이 socket 중심에 오도록 drag 위치 조정
+      const snappedX = drag.x + (socketCenter.x - plugCenter.x);
+      const snappedY = drag.y + (socketCenter.y - plugCenter.y);
+
+      if (!best || d < best.d) {
+        best = { edgeIndex: socket.edgeIndex, d, x: snappedX, y: snappedY };
+      }
+    }
+  }
+
+  if (!best) {
+    return { canSnap: false, edgeIndex: null, x: drag.x, y: drag.y, targetId: null };
+  }
+
+  return {
+    canSnap: true,
+    edgeIndex: best.edgeIndex,
+    x: best.x,
+    y: best.y,
+    targetId: tail.blockId,
+  };
 }

--- a/src/feature/block/blockBuild/utils/snapToTail.ts
+++ b/src/feature/block/blockBuild/utils/snapToTail.ts
@@ -1,4 +1,5 @@
-import { type Point, type Connector, getConnectorCenter } from '@/shared/components/Block/blockShape';
+import { type Point, getConnectorCenter } from '@/shared/components/Block/blockShape';
+import type { Block } from '../types/block';
 
 export type TailSnapResult = {
   canSnap: boolean;
@@ -15,20 +16,11 @@ const dist = (a: Point, b: Point) => {
   return Math.sqrt(dx * dx + dy * dy);
 };
 
-export interface SnapBlock {
-  blockId: number;
-  x: number;
-  y: number;
-  points: Point[];
-  connectors: Connector[];
-}
+// Block에서 스냅 계산에 필요한 속성만 추출
+export type SnapBlock = Pick<Block, 'blockId' | 'x' | 'y' | 'points' | 'connectors'>;
 
-interface SnapCandidate {
-  x: number;
-  y: number;
-  points: Point[];
-  connectors: Connector[];
-}
+// 드래그 중인 블록 후보 (아직 blockId 없음)
+type SnapCandidate = Omit<SnapBlock, 'blockId'>;
 
 const DEFAULT_TAB_WIDTH = 42;
 

--- a/src/pages/BlockPage/BlockPage.tsx
+++ b/src/pages/BlockPage/BlockPage.tsx
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-import { Block } from '@/shared/components/Block/Block';
-import { convertToPolygonConnections, createRectPoints } from '@/shared/components/Block/blockShape';
 import BlockEditor from '@/feature/block/blockBuild/components/BlockEditor';
 
 const BlockPage = () => {
@@ -8,28 +5,6 @@ const BlockPage = () => {
     <div className="flex h-[1091px] w-screen overflow-hidden">
       {/* TODO: 여기다가 여행 타이틀 */}
       <BlockEditor />
-      
-      <Block
-        category="식당"
-        title="향라식당"
-        duration="2시간"
-        icon="food"
-        points={[
-          { x: 0, y: 0 },
-          { x: 160, y: 0 },
-          { x: 160, y: 160 },
-          { x: 320, y: 160 },
-          { x: 320, y: 320 },
-          { x: 0, y: 320 },
-        ]}
-        connections={[
-          { edgeIndex: 0, type: 'plug', align: 'start' },
-          { edgeIndex: 3, type: 'socket', align: 'end' },
-          { edgeIndex: 4, type: 'socket', align: 'start' },
-          { edgeIndex: 5, type: 'plug', align: 'end' },
-        ]}
-      />
-
     </div>
   );
 };

--- a/src/pages/BlockPage/BlockPage.tsx
+++ b/src/pages/BlockPage/BlockPage.tsx
@@ -1,3 +1,6 @@
+<<<<<<< HEAD
+import { Block } from '@/shared/components/Block/Block';
+import { convertToPolygonConnections, createRectPoints } from '@/shared/components/Block/blockShape';
 import BlockEditor from '@/feature/block/blockBuild/components/BlockEditor';
 
 const BlockPage = () => {
@@ -5,6 +8,28 @@ const BlockPage = () => {
     <div className="flex h-[1091px] w-screen overflow-hidden">
       {/* TODO: 여기다가 여행 타이틀 */}
       <BlockEditor />
+      
+      <Block
+        category="식당"
+        title="향라식당"
+        duration="2시간"
+        icon="food"
+        points={[
+          { x: 0, y: 0 },
+          { x: 160, y: 0 },
+          { x: 160, y: 160 },
+          { x: 320, y: 160 },
+          { x: 320, y: 320 },
+          { x: 0, y: 320 },
+        ]}
+        connections={[
+          { edgeIndex: 0, type: 'plug', align: 'start' },
+          { edgeIndex: 3, type: 'socket', align: 'end' },
+          { edgeIndex: 4, type: 'socket', align: 'start' },
+          { edgeIndex: 5, type: 'plug', align: 'end' },
+        ]}
+      />
+
     </div>
   );
 };

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -50,7 +50,9 @@ const TestPage = () => {
 
   return (
     <>
-      <BlockEditor />
+      <div className="w-screen h-screen">
+        <BlockEditor />
+      </div>
 
       <div className="flex flex-col gap-4">
         <h1>✅ Block.tsx</h1>

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -11,6 +11,7 @@ import TemplateSwiper from '@/feature/template/TemplateSwiper';
 import { mockRecommendedTemplates } from '@/feature/template/template.data';
 import { mockPopularTemplates } from '@/feature/template/template.data';
 import { Block } from '@/shared/components/Block/Block';
+import { createRectPoints } from '@/shared/components/Block/blockShape';
 
 const TestPage = () => {
   const schema = z.object({
@@ -48,27 +49,44 @@ const TestPage = () => {
 
   return (
     <>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
         <h1>✅ Block.tsx</h1>
-        <Block
-          category="식당"
-          title="향라식당"
-          duration="2시간"
-          points={[
-            { x: 0, y: 0 },
-            { x: 160, y: 0 },
-            { x: 160, y: 160 },
-            { x: 320, y: 160 },
-            { x: 320, y: 320 },
-            { x: 0, y: 320 },
-          ]}
-          connections={[
-            { edgeIndex: 0, type: 'plug', align: 'start' },
-            { edgeIndex: 3, type: 'socket', align: 'end' },
-            { edgeIndex: 4, type: 'socket', align: 'start' },
-            { edgeIndex: 5, type: 'plug', align: 'end' },
-          ]}
-        />
+
+        <div className="flex gap-6">
+          <Block
+            category="식당"
+            title="향라식당"
+            duration="2시간"
+            points={[
+              { x: 0, y: 0 },
+              { x: 160, y: 0 },
+              { x: 160, y: 160 },
+              { x: 320, y: 160 },
+              { x: 320, y: 320 },
+              { x: 0, y: 320 },
+            ]}
+            connections={[
+              { edgeIndex: 0, type: 'plug', align: 'start' },
+              { edgeIndex: 3, type: 'socket', align: 'end' },
+              { edgeIndex: 4, type: 'socket', align: 'start' },
+              { edgeIndex: 5, type: 'plug', align: 'end' },
+            ]}
+          />
+
+          <Block
+            category=""
+            title="향라식당"
+            duration="1시간"
+            color="text-positive"
+            points={createRectPoints(150, 300)}
+            connections={[
+              { edgeIndex: 0, type: 'plug', align: 'start' },
+              { edgeIndex: 1, type: 'socket', align: 'end' },
+              { edgeIndex: 2, type: 'socket', align: 'start' },
+              { edgeIndex: 3, type: 'plug', align: 'end' },
+            ]}
+          />
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -10,6 +10,7 @@ import Alert from '@/shared/components/Form/Alert';
 import TemplateSwiper from '@/feature/template/TemplateSwiper';
 import { mockRecommendedTemplates } from '@/feature/template/template.data';
 import { mockPopularTemplates } from '@/feature/template/template.data';
+import { Block } from '@/shared/components/Block/Block';
 
 const TestPage = () => {
   const schema = z.object({
@@ -47,6 +48,29 @@ const TestPage = () => {
 
   return (
     <>
+      <div className="flex flex-col gap-2">
+        <h1>✅ Block.tsx</h1>
+        <Block
+          category="식당"
+          title="향라식당"
+          duration="2시간"
+          points={[
+            { x: 0, y: 0 },
+            { x: 160, y: 0 },
+            { x: 160, y: 160 },
+            { x: 320, y: 160 },
+            { x: 320, y: 320 },
+            { x: 0, y: 320 },
+          ]}
+          connections={[
+            { edgeIndex: 0, type: 'plug', align: 'start' },
+            { edgeIndex: 3, type: 'socket', align: 'end' },
+            { edgeIndex: 4, type: 'socket', align: 'start' },
+            { edgeIndex: 5, type: 'plug', align: 'end' },
+          ]}
+        />
+      </div>
+
       <div className="flex flex-col gap-2">
         <h1>✅ Button.tsx</h1>
         <Button text="Vlock 쌓으러 가기" />

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -12,6 +12,7 @@ import { mockRecommendedTemplates } from '@/feature/template/template.data';
 import { mockPopularTemplates } from '@/feature/template/template.data';
 import { Block } from '@/shared/components/Block/Block';
 import { createRectPoints } from '@/shared/components/Block/blockShape';
+import BlockEditor from '@/feature/block/blockBuild/components/BlockEditor';
 
 const TestPage = () => {
   const schema = z.object({
@@ -49,6 +50,8 @@ const TestPage = () => {
 
   return (
     <>
+      <BlockEditor />
+
       <div className="flex flex-col gap-4">
         <h1>✅ Block.tsx</h1>
 

--- a/src/shared/assets/icon-drag-handle.svg
+++ b/src/shared/assets/icon-drag-handle.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="9" cy="5" r="2" fill="currentColor"/>
+<circle cx="15" cy="5" r="2" fill="currentColor"/>
+<circle cx="9" cy="12" r="2" fill="currentColor"/>
+<circle cx="15" cy="12" r="2" fill="currentColor"/>
+<circle cx="9" cy="19" r="2" fill="currentColor"/>
+<circle cx="15" cy="19" r="2" fill="currentColor"/>
+</svg>

--- a/src/shared/components/Block/Block.tsx
+++ b/src/shared/components/Block/Block.tsx
@@ -16,8 +16,8 @@ interface BlockProps {
 }
 
 const TAB_HEIGHT = 16;
-const TAB_WIDTH = 40;
-const RADIUS = 24;
+const TAB_WIDTH = 42;
+const RADIUS = 5;
 
 export const Block = ({
   title,
@@ -28,50 +28,70 @@ export const Block = ({
   connections = [],
   points,
 }: BlockProps) => {
-  const clipPath = useMemo(() => {
-    return createPolygonBlockPath(points, RADIUS, TAB_WIDTH, TAB_HEIGHT, connections);
-  }, [points, connections]);
+  const { totalWidth, totalHeight, contentTop, contentLeft, contentWidth, contentHeight, normalizedPoints } =
+    useMemo(() => {
+      if (!points || points.length === 0) {
+        return {
+          totalWidth: 0,
+          totalHeight: 0,
+          contentTop: 0,
+          contentLeft: 0,
+          contentWidth: 0,
+          contentHeight: 0,
+          normalizedPoints: [],
+        };
+      }
+      const xs = points.map((p) => p.x);
+      const ys = points.map((p) => p.y);
+      const minX = Math.min(...xs);
+      const maxX = Math.max(...xs);
+      const minY = Math.min(...ys);
+      const maxY = Math.max(...ys);
 
-  // Dimension Calculation
-  const { totalWidth, totalHeight, contentTop, contentLeft, contentWidth, contentHeight } = useMemo(() => {
-    if (!points || points.length === 0) {
-      return { totalWidth: 0, totalHeight: 0, contentTop: 0, contentLeft: 0, contentWidth: 0, contentHeight: 0 };
-    }
-    const xs = points.map((p) => p.x);
-    const ys = points.map((p) => p.y);
-    const minX = Math.min(...xs);
-    const maxX = Math.max(...xs);
-    const minY = Math.min(...ys);
-    const maxY = Math.max(...ys);
+      const w = maxX - minX;
+      const h = maxY - minY;
 
-    return {
-      totalWidth: maxX,
-      totalHeight: maxY,
-      contentTop: minY,
-      contentLeft: minX,
-      contentWidth: maxX - minX,
-      contentHeight: maxY - minY,
-    };
-  }, [points]);
+      const normalized = points.map((p) => ({ x: p.x - minX, y: p.y - minY }));
+
+      return {
+        totalWidth: w,
+        totalHeight: h,
+        contentTop: 0,
+        contentLeft: 0,
+        contentWidth: w,
+        contentHeight: h,
+        normalizedPoints: normalized,
+      };
+    }, [points]);
+
+  const pathD = useMemo(() => {
+    return createPolygonBlockPath(normalizedPoints, RADIUS, TAB_WIDTH, TAB_HEIGHT, connections);
+  }, [normalizedPoints, connections]);
 
   return (
-    <div className={`relative drop-shadow-md ${className}`} style={{ width: totalWidth, height: totalHeight }}>
-      <div className="w-full h-full bg-negative text-white" style={{ clipPath: `path('${clipPath}')` }}>
-        <div
-          className="absolute flex flex-col p-5"
-          style={{
-            top: contentTop,
-            left: contentLeft,
-            width: contentWidth,
-            height: contentHeight,
-          }}>
-          <div className="flex flex-col gap-2">
-            <BlockContent icon={icon} category={category} title={title} />
-            <BlockDurationBadge duration={duration} />
-          </div>
-          <div className="absolute bottom-4.5 right-4.5">
-            <AppIcon name="dragHandle" width={20} height={20} className="opacity-80" />
-          </div>
+    <div className={`relative ${className}`} style={{ width: totalWidth, height: totalHeight }}>
+      {/* SVG Layer */}
+      <svg
+        className="absolute top-0 left-0 w-full h-full overflow-visible drop-shadow-md text-negative"
+        style={{ pointerEvents: 'none' }}>
+        <path d={pathD} fill="currentColor" style={{ pointerEvents: 'auto' }} />
+      </svg>
+
+      {/* Content Layer */}
+      <div
+        className="absolute flex flex-col p-5 text-white"
+        style={{
+          top: contentTop,
+          left: contentLeft,
+          width: contentWidth,
+          height: contentHeight,
+        }}>
+        <div className="flex flex-col gap-2">
+          <BlockContent icon={icon} category={category} title={title} />
+          <BlockDurationBadge duration={duration} />
+        </div>
+        <div className="absolute bottom-4.5 right-4.5">
+          <AppIcon name="dragHandle" width={20} height={20} className="opacity-80" />
         </div>
       </div>
     </div>

--- a/src/shared/components/Block/Block.tsx
+++ b/src/shared/components/Block/Block.tsx
@@ -4,12 +4,14 @@ import { type IconName } from '@/shared/ui/icon/registry';
 import { createPolygonBlockPath, type Connector, type Point } from './blockShape';
 import { BlockContent } from './BlockContent';
 import { BlockDurationBadge } from './BlockDurationBadge';
+import clsx from 'clsx';
 
 interface BlockProps {
   title: string;
   category: string;
   duration: string;
   icon?: IconName;
+  color?: string;
   className?: string;
   connections?: Connector[];
   points: Point[];
@@ -24,6 +26,7 @@ export const Block = ({
   category,
   duration,
   icon = 'food',
+  color = 'text-negative',
   className,
   connections = [],
   points,
@@ -72,7 +75,7 @@ export const Block = ({
     <div className={`relative ${className}`} style={{ width: totalWidth, height: totalHeight }}>
       {/* SVG Layer */}
       <svg
-        className="absolute top-0 left-0 w-full h-full overflow-visible drop-shadow-md text-negative"
+        className={clsx('absolute top-0 left-0 w-full h-full overflow-visible drop-shadow-md', color)}
         style={{ pointerEvents: 'none' }}>
         <path d={pathD} fill="currentColor" style={{ pointerEvents: 'auto' }} />
       </svg>

--- a/src/shared/components/Block/Block.tsx
+++ b/src/shared/components/Block/Block.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { AppIcon } from '@/shared/ui/icon/AppIcon';
 import { type IconName } from '@/shared/ui/icon/registry';
-import { createBlockPath, type BlockConnections } from './blockShape';
+import { createPolygonBlockPath, type Connector, type Point } from './blockShape';
 import { BlockContent } from './BlockContent';
 import { BlockDurationBadge } from './BlockDurationBadge';
 
@@ -11,14 +11,12 @@ interface BlockProps {
   duration: string;
   icon?: IconName;
   className?: string;
-  connections?: BlockConnections;
-  width?: number;
-  height?: number;
+  connections?: Connector[];
+  points: Point[];
 }
 
 const TAB_HEIGHT = 16;
 const TAB_WIDTH = 40;
-const DEFAULT_SIZE = 160;
 const RADIUS = 24;
 
 export const Block = ({
@@ -28,47 +26,50 @@ export const Block = ({
   icon = 'food',
   className,
   connections = [],
-  width = DEFAULT_SIZE,
-  height = DEFAULT_SIZE,
+  points,
 }: BlockProps) => {
-  const effectiveConnections: BlockConnections =
-    connections.length === 0
-      ? [
-          { direction: 'top', type: 'plug', align: 'center' },
-          { direction: 'right', type: 'socket', align: 'center' },
-          { direction: 'bottom', type: 'socket', align: 'center' },
-          { direction: 'left', type: 'plug', align: 'center' },
-        ]
-      : connections;
+  const clipPath = useMemo(() => {
+    return createPolygonBlockPath(points, RADIUS, TAB_WIDTH, TAB_HEIGHT, connections);
+  }, [points, connections]);
 
-  const clipPath = useMemo(
-    () => createBlockPath(width, height, RADIUS, TAB_WIDTH, TAB_HEIGHT, effectiveConnections),
-    [effectiveConnections, width, height],
-  );
+  // Dimension Calculation
+  const { totalWidth, totalHeight, contentTop, contentLeft, contentWidth, contentHeight } = useMemo(() => {
+    if (!points || points.length === 0) {
+      return { totalWidth: 0, totalHeight: 0, contentTop: 0, contentLeft: 0, contentWidth: 0, contentHeight: 0 };
+    }
+    const xs = points.map((p) => p.x);
+    const ys = points.map((p) => p.y);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
 
-  // Total size calculation
-  const totalWidth = width + TAB_HEIGHT * 2;
-  const totalHeight = height + TAB_HEIGHT * 2;
+    return {
+      totalWidth: maxX,
+      totalHeight: maxY,
+      contentTop: minY,
+      contentLeft: minX,
+      contentWidth: maxX - minX,
+      contentHeight: maxY - minY,
+    };
+  }, [points]);
 
   return (
     <div className={`relative drop-shadow-md ${className}`} style={{ width: totalWidth, height: totalHeight }}>
-      {/* Clipped Shape */}
-      <div className="w-full h-full bg-[#fd7565] text-white" style={{ clipPath: `path('${clipPath}')` }}>
-        {/* Content Container - Positioned to align with the Body (160x160) */}
+      <div className="w-full h-full bg-negative text-white" style={{ clipPath: `path('${clipPath}')` }}>
         <div
           className="absolute flex flex-col p-5"
           style={{
-            top: TAB_HEIGHT,
-            left: TAB_HEIGHT,
-            width: width,
-            height: height,
+            top: contentTop,
+            left: contentLeft,
+            width: contentWidth,
+            height: contentHeight,
           }}>
-          <BlockContent icon={icon} category={category} title={title} />
-
-          <div className="absolute bottom-5 left-5">
+          <div className="flex flex-col gap-2">
+            <BlockContent icon={icon} category={category} title={title} />
             <BlockDurationBadge duration={duration} />
           </div>
-          <div className="absolute bottom-[18px] right-[18px]">
+          <div className="absolute bottom-4.5 right-4.5">
             <AppIcon name="dragHandle" width={20} height={20} className="opacity-80" />
           </div>
         </div>

--- a/src/shared/components/Block/Block.tsx
+++ b/src/shared/components/Block/Block.tsx
@@ -82,7 +82,7 @@ export const Block = ({
 
       {/* Content Layer */}
       <div
-        className="absolute flex flex-col p-5 text-white"
+        className="absolute flex flex-col px-3 py-5 text-white"
         style={{
           top: contentTop,
           left: contentLeft,

--- a/src/shared/components/Block/Block.tsx
+++ b/src/shared/components/Block/Block.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { AppIcon } from '@/shared/ui/icon/AppIcon';
 import { type IconName } from '@/shared/ui/icon/registry';
-import { createPolygonBlockPath, type Connector, type Point } from './blockShape';
+import { type Connector, type Point, getBoundingBox, useBlockPath } from './blockShape';
 import { BlockContent } from './BlockContent';
 import { BlockDurationBadge } from './BlockDurationBadge';
 import clsx from 'clsx';
@@ -17,10 +17,6 @@ interface BlockProps {
   points: Point[];
 }
 
-const TAB_HEIGHT = 16;
-const TAB_WIDTH = 42;
-const RADIUS = 5;
-
 export const Block = ({
   title,
   category,
@@ -31,45 +27,30 @@ export const Block = ({
   connections = [],
   points,
 }: BlockProps) => {
-  const { totalWidth, totalHeight, contentTop, contentLeft, contentWidth, contentHeight, normalizedPoints } =
-    useMemo(() => {
-      if (!points || points.length === 0) {
-        return {
-          totalWidth: 0,
-          totalHeight: 0,
-          contentTop: 0,
-          contentLeft: 0,
-          contentWidth: 0,
-          contentHeight: 0,
-          normalizedPoints: [],
-        };
-      }
-      const xs = points.map((p) => p.x);
-      const ys = points.map((p) => p.y);
-      const minX = Math.min(...xs);
-      const maxX = Math.max(...xs);
-      const minY = Math.min(...ys);
-      const maxY = Math.max(...ys);
-
-      const w = maxX - minX;
-      const h = maxY - minY;
-
-      const normalized = points.map((p) => ({ x: p.x - minX, y: p.y - minY }));
-
+  const { totalWidth, totalHeight, contentTop, contentLeft, contentWidth, contentHeight } = useMemo(() => {
+    if (!points || points.length === 0) {
       return {
-        totalWidth: w,
-        totalHeight: h,
+        totalWidth: 0,
+        totalHeight: 0,
         contentTop: 0,
         contentLeft: 0,
-        contentWidth: w,
-        contentHeight: h,
-        normalizedPoints: normalized,
+        contentWidth: 0,
+        contentHeight: 0,
       };
-    }, [points]);
+    }
+    const { w, h } = getBoundingBox(points);
 
-  const pathD = useMemo(() => {
-    return createPolygonBlockPath(normalizedPoints, RADIUS, TAB_WIDTH, TAB_HEIGHT, connections);
-  }, [normalizedPoints, connections]);
+    return {
+      totalWidth: w,
+      totalHeight: h,
+      contentTop: 0,
+      contentLeft: 0,
+      contentWidth: w,
+      contentHeight: h,
+    };
+  }, [points]);
+
+  const pathD = useBlockPath(points, connections);
 
   return (
     <div className={`relative ${className}`} style={{ width: totalWidth, height: totalHeight }}>

--- a/src/shared/components/Block/Block.tsx
+++ b/src/shared/components/Block/Block.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+import { AppIcon } from '@/shared/ui/icon/AppIcon';
+import { type IconName } from '@/shared/ui/icon/registry';
+import { createBlockPath, type BlockConnections } from './blockShape';
+import { BlockContent } from './BlockContent';
+import { BlockDurationBadge } from './BlockDurationBadge';
+
+interface BlockProps {
+  title: string;
+  category: string;
+  duration: string;
+  icon?: IconName;
+  className?: string;
+  connections?: BlockConnections;
+  width?: number;
+  height?: number;
+}
+
+const TAB_HEIGHT = 16;
+const TAB_WIDTH = 40;
+const DEFAULT_SIZE = 160;
+const RADIUS = 24;
+
+export const Block = ({
+  title,
+  category,
+  duration,
+  icon = 'food',
+  className,
+  connections = [],
+  width = DEFAULT_SIZE,
+  height = DEFAULT_SIZE,
+}: BlockProps) => {
+  const effectiveConnections: BlockConnections =
+    connections.length === 0
+      ? [
+          { direction: 'top', type: 'plug', align: 'center' },
+          { direction: 'right', type: 'socket', align: 'center' },
+          { direction: 'bottom', type: 'socket', align: 'center' },
+          { direction: 'left', type: 'plug', align: 'center' },
+        ]
+      : connections;
+
+  const clipPath = useMemo(
+    () => createBlockPath(width, height, RADIUS, TAB_WIDTH, TAB_HEIGHT, effectiveConnections),
+    [effectiveConnections, width, height],
+  );
+
+  // Total size calculation
+  const totalWidth = width + TAB_HEIGHT * 2;
+  const totalHeight = height + TAB_HEIGHT * 2;
+
+  return (
+    <div className={`relative drop-shadow-md ${className}`} style={{ width: totalWidth, height: totalHeight }}>
+      {/* Clipped Shape */}
+      <div className="w-full h-full bg-[#fd7565] text-white" style={{ clipPath: `path('${clipPath}')` }}>
+        {/* Content Container - Positioned to align with the Body (160x160) */}
+        <div
+          className="absolute flex flex-col p-5"
+          style={{
+            top: TAB_HEIGHT,
+            left: TAB_HEIGHT,
+            width: width,
+            height: height,
+          }}>
+          <BlockContent icon={icon} category={category} title={title} />
+
+          <div className="absolute bottom-5 left-5">
+            <BlockDurationBadge duration={duration} />
+          </div>
+          <div className="absolute bottom-[18px] right-[18px]">
+            <AppIcon name="dragHandle" width={20} height={20} className="opacity-80" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/shared/components/Block/BlockContent.tsx
+++ b/src/shared/components/Block/BlockContent.tsx
@@ -12,8 +12,8 @@ export const BlockContent = ({ icon, category, title }: BlockContentProps) => {
     <div className="flex items-center gap-2 mt-1">
       <AppIcon name={icon} width={30} height={30} />
       <div className="flex flex-col">
-        <span className="text-[12px] font-normal text-base-color-5">{category}</span>
-        <span className="leading-tight b5">{title}</span>
+        <span className="text-[12px] font-normal text-base-color-5 line-clamp-1">{category}</span>
+        <span className="leading-tight b5 line-clamp-1">{title}</span>
       </div>
     </div>
   );

--- a/src/shared/components/Block/BlockContent.tsx
+++ b/src/shared/components/Block/BlockContent.tsx
@@ -9,7 +9,7 @@ interface BlockContentProps {
 
 export const BlockContent = ({ icon, category, title }: BlockContentProps) => {
   return (
-    <div className="flex items-center justify-center gap-2 mt-1">
+    <div className="flex items-center gap-2 mt-1">
       <AppIcon name={icon} width={30} height={30} />
       <div className="flex flex-col">
         <span className="text-[12px] font-normal text-base-color-5">{category}</span>

--- a/src/shared/components/Block/BlockContent.tsx
+++ b/src/shared/components/Block/BlockContent.tsx
@@ -13,7 +13,7 @@ export const BlockContent = ({ icon, category, title }: BlockContentProps) => {
       <AppIcon name={icon} width={30} height={30} />
       <div className="flex flex-col">
         <span className="text-[12px] font-normal text-base-color-5">{category}</span>
-        <span className="leading-tight h7">{title}</span>
+        <span className="leading-tight b5">{title}</span>
       </div>
     </div>
   );

--- a/src/shared/components/Block/BlockContent.tsx
+++ b/src/shared/components/Block/BlockContent.tsx
@@ -1,0 +1,20 @@
+import { AppIcon } from '@/shared/ui/icon/AppIcon';
+import { type IconName } from '@/shared/ui/icon/registry';
+
+interface BlockContentProps {
+  icon: IconName;
+  category: string;
+  title: string;
+}
+
+export const BlockContent = ({ icon, category, title }: BlockContentProps) => {
+  return (
+    <div className="flex items-center justify-center gap-2 mt-1">
+      <AppIcon name={icon} width={30} height={30} />
+      <div className="flex flex-col">
+        <span className="text-[12px] font-normal text-base-color-5">{category}</span>
+        <span className="leading-tight h7">{title}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/shared/components/Block/BlockDurationBadge.tsx
+++ b/src/shared/components/Block/BlockDurationBadge.tsx
@@ -6,7 +6,7 @@ interface BlockDurationBadgeProps {
 
 export const BlockDurationBadge = ({ duration }: BlockDurationBadgeProps) => {
   return (
-    <div className="flex items-center gap-1 bg-white px-2.5 py-1 rounded-full shadow-sm">
+    <div className="flex items-center gap-1 bg-white px-2.5 py-1 rounded-full shadow-sm w-fit">
       <AppIcon name="clock" width={14} height={14} className="text-[#3c4ef4]" />
       <span className="text-[#3c4ef4] text-[13px] font-bold leading-none pt-[1px]">{duration}</span>
     </div>

--- a/src/shared/components/Block/BlockDurationBadge.tsx
+++ b/src/shared/components/Block/BlockDurationBadge.tsx
@@ -1,0 +1,14 @@
+import { AppIcon } from '@/shared/ui/icon/AppIcon';
+
+interface BlockDurationBadgeProps {
+  duration: string;
+}
+
+export const BlockDurationBadge = ({ duration }: BlockDurationBadgeProps) => {
+  return (
+    <div className="flex items-center gap-1 bg-white px-2.5 py-1 rounded-full shadow-sm">
+      <AppIcon name="clock" width={14} height={14} className="text-[#3c4ef4]" />
+      <span className="text-[#3c4ef4] text-[13px] font-bold leading-none pt-[1px]">{duration}</span>
+    </div>
+  );
+};

--- a/src/shared/components/Block/blockShape.ts
+++ b/src/shared/components/Block/blockShape.ts
@@ -54,7 +54,7 @@ export const createConnectorPath = (
   tabHeight: number,
   type: ConnectorType,
   direction: ConnectorDirection,
-  inset: number = 6,
+  inset: number = 5,
 ): string => {
   const isPlug = type === 'plug';
 
@@ -137,7 +137,7 @@ export const createConnectorPath = (
   return ` Q ${c1x} ${c1y} ${p1x} ${p1y} L ${p2x} ${p2y} Q ${c2x} ${c2y} ${p3x} ${p3y} L ${p4x} ${p4y} Q ${c3x} ${c3y} ${p5x} ${p5y} L ${p6x} ${p6y} Q ${c4x} ${c4y} ${destX} ${destY}`;
 };
 
-export const createRectPoints = (width: number, height: number, startX: number = 16, startY: number = 16): Point[] => {
+export const createRectPoints = (width: number, height: number, startX: number = 0, startY: number = 0): Point[] => {
   return [
     { x: startX, y: startY },
     { x: startX + width, y: startY },
@@ -211,7 +211,7 @@ export const createPolygonBlockPath = (
 
       path += ` L ${tx} ${ty}`;
 
-      path += createConnectorPath(tx, ty, tabWidth, tabHeight, conn.type, direction);
+      path += createConnectorPath(tx, ty, tabWidth, tabHeight, conn.type, direction, radius);
 
       path += ` L ${endX} ${endY}`;
     } else {

--- a/src/shared/components/Block/blockShape.ts
+++ b/src/shared/components/Block/blockShape.ts
@@ -95,6 +95,25 @@ export const getConnectorCenter = (points: Point[], connector: Connector, tabWid
   };
 };
 
+// points 배열에서 bounding box 크기 계산
+export const getBoundingBox = (points: Point[]): { w: number; h: number } => {
+  if (points.length === 0) return { w: 0, h: 0 };
+
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+
+  return { w: maxX - minX, h: maxY - minY };
+};
+
 export const createConnectorPath = (
   x: number,
   y: number,

--- a/src/shared/components/Block/blockShape.ts
+++ b/src/shared/components/Block/blockShape.ts
@@ -1,14 +1,51 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
 export type ConnectorType = 'plug' | 'socket';
 export type ConnectorDirection = 'top' | 'right' | 'bottom' | 'left';
 export type ConnectorAlignment = 'start' | 'center' | 'end';
 
 export interface Connector {
-  direction: ConnectorDirection;
   type: ConnectorType;
+  edgeIndex: number;
   align?: ConnectorAlignment;
 }
 
-export type BlockConnections = Connector[];
+// 편의를 위해서 폴리곤을 사각형으로 표현하는 경우 사용함
+export interface DirectionalConnector {
+  type: ConnectorType;
+  direction: ConnectorDirection;
+  align?: ConnectorAlignment;
+}
+
+export type BlockConnector = Connector | DirectionalConnector;
+export type BlockConnections = BlockConnector[];
+
+export const convertToPolygonConnections = (connections: BlockConnections): Connector[] => {
+  const polygonConnections: Connector[] = [];
+  connections.forEach((c) => {
+    if ('edgeIndex' in c) {
+      polygonConnections.push(c);
+    } else {
+      let edgeIndex = -1;
+      if (c.direction === 'top') edgeIndex = 0;
+      else if (c.direction === 'right') edgeIndex = 1;
+      else if (c.direction === 'bottom') edgeIndex = 2;
+      else if (c.direction === 'left') edgeIndex = 3;
+
+      if (edgeIndex !== -1) {
+        polygonConnections.push({
+          type: c.type,
+          align: c.align,
+          edgeIndex,
+        });
+      }
+    }
+  });
+  return polygonConnections;
+};
 
 export const createConnectorPath = (
   x: number,
@@ -100,107 +137,105 @@ export const createConnectorPath = (
   return ` Q ${c1x} ${c1y} ${p1x} ${p1y} L ${p2x} ${p2y} Q ${c2x} ${c2y} ${p3x} ${p3y} L ${p4x} ${p4y} Q ${c3x} ${c3y} ${p5x} ${p5y} L ${p6x} ${p6y} Q ${c4x} ${c4y} ${destX} ${destY}`;
 };
 
-export const createBlockPath = (
-  width: number,
-  height: number,
+export const createRectPoints = (width: number, height: number, startX: number = 16, startY: number = 16): Point[] => {
+  return [
+    { x: startX, y: startY },
+    { x: startX + width, y: startY },
+    { x: startX + width, y: startY + height },
+    { x: startX, y: startY + height },
+  ];
+};
+
+export const createPolygonBlockPath = (
+  points: Point[],
   radius: number,
   tabWidth: number,
   tabHeight: number,
-  connections: BlockConnections,
-  startX: number = tabHeight,
-  startY: number = tabHeight,
+  connections: Connector[],
 ): string => {
-  const endX = startX + width;
-  const endY = startY + height;
+  if (points.length < 3) return '';
 
+  let path = '';
   const ALIGN_MARGIN = 30;
 
-  const getTabStart = (edgeLength: number, align?: ConnectorAlignment) => {
-    switch (align) {
-      case 'start':
-        return ALIGN_MARGIN;
-      case 'end':
-        return edgeLength - tabWidth - ALIGN_MARGIN;
-      case 'center':
-      default:
-        return (edgeLength - tabWidth) / 2;
-    }
-  };
-
-  const connMap: Partial<Record<ConnectorDirection, Connector>> = {};
+  // Map connectors to edges by index
+  const connMap: Record<number, Connector> = {};
   connections.forEach((c) => {
-    connMap[c.direction] = c;
+    connMap[c.edgeIndex] = c;
   });
 
-  // Helper for straight lines and corners
-  //
-  //   (startX, startY)
-  //      *-----------------------* (endX, startY)
-  //      |  Top Edge (L->R)      |
-  //      |                       |
-  // Left |                       | Right
-  // Edge |                       | Edge
-  // (B->T)|                       | (T->B)
-  //      |                       |
-  //      *-----------------------* (endX, endY)
-  //   (startX, endY)  Bottom Edge (R->L)
-  //
-  let path = `M ${startX} ${startY + radius}`;
+  const len = points.length;
 
-  path += ` Q ${startX} ${startY} ${startX + radius} ${startY}`;
-  const topConn = connMap.top;
-  if (!topConn) {
-    path += ` L ${endX - radius} ${startY}`;
-  } else {
-    const offset = getTabStart(width, topConn.align);
-    const tabStart = startX + offset;
+  for (let i = 0; i < len; i++) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % len];
 
-    path += ` L ${tabStart} ${startY}`;
-    path += createConnectorPath(tabStart, startY, tabWidth, tabHeight, topConn.type, 'top');
-    path += ` L ${endX - radius} ${startY}`;
+    // Vector P1->P2
+    const vx = p2.x - p1.x;
+    const vy = p2.y - p1.y;
+    const dist = Math.sqrt(vx * vx + vy * vy);
+
+    // Normalized direction
+    const dx = vx / dist;
+    const dy = vy / dist;
+
+    let direction: ConnectorDirection = 'top';
+    if (Math.abs(dx) > Math.abs(dy)) {
+      direction = dx > 0 ? 'top' : 'bottom';
+    } else {
+      direction = dy > 0 ? 'right' : 'left';
+    }
+
+    const startX = p1.x + dx * radius;
+    const startY = p1.y + dy * radius;
+
+    const endX = p2.x - dx * radius;
+    const endY = p2.y - dy * radius;
+
+    if (i === 0) {
+      path += `M ${startX} ${startY}`;
+    } else {
+      path += ` Q ${p1.x} ${p1.y} ${startX} ${startY}`;
+    }
+
+    const conn = connMap[i];
+    if (conn) {
+      let tabStartDist = 0;
+
+      if (conn.align === 'start') tabStartDist = ALIGN_MARGIN;
+      else if (conn.align === 'end') tabStartDist = dist - tabWidth - ALIGN_MARGIN;
+      else tabStartDist = (dist - tabWidth) / 2;
+
+      const tx = p1.x + dx * tabStartDist;
+      const ty = p1.y + dy * tabStartDist;
+
+      path += ` L ${tx} ${ty}`;
+
+      path += createConnectorPath(tx, ty, tabWidth, tabHeight, conn.type, direction);
+
+      path += ` L ${endX} ${endY}`;
+    } else {
+      path += ` L ${endX} ${endY}`;
+    }
   }
 
-  path += ` Q ${endX} ${startY} ${endX} ${startY + radius}`;
-  const rightConn = connMap.right;
-  if (!rightConn) {
-    path += ` L ${endX} ${endY - radius}`;
-  } else {
-    const offset = getTabStart(height, rightConn.align);
-    const tabStart = startY + offset;
-
-    path += ` L ${endX} ${tabStart}`;
-    path += createConnectorPath(endX, tabStart, tabWidth, tabHeight, rightConn.type, 'right');
-    path += ` L ${endX} ${endY - radius}`;
-  }
-
-  path += ` Q ${endX} ${endY} ${endX - radius} ${endY}`;
-  const bottomConn = connMap.bottom;
-  if (!bottomConn) {
-    path += ` L ${startX + radius} ${endY}`;
-  } else {
-    const offset = getTabStart(width, bottomConn.align);
-    const tabVisualStart = startX + offset;
-    const tabVisualEnd = tabVisualStart + tabWidth;
-
-    path += ` L ${tabVisualEnd} ${endY}`;
-    path += createConnectorPath(tabVisualEnd, endY, tabWidth, tabHeight, bottomConn.type, 'bottom');
-    path += ` L ${startX + radius} ${endY}`;
-  }
-
-  path += ` Q ${startX} ${endY} ${startX} ${endY - radius}`;
-  const leftConn = connMap.left;
-  if (!leftConn) {
-    path += ` L ${startX} ${startY + radius}`;
-  } else {
-    const offset = getTabStart(height, leftConn.align);
-    const tabVisualStart = startY + offset;
-    const tabVisualEnd = tabVisualStart + tabWidth;
-
-    path += ` L ${startX} ${tabVisualEnd}`;
-    path += createConnectorPath(startX, tabVisualEnd, tabWidth, tabHeight, leftConn.type, 'left');
-    path += ` L ${startX} ${startY + radius}`;
-  }
+  path += ` Q ${points[0].x} ${points[0].y} ${points[0].x + ((points[1].x - points[0].x) / Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)) * radius} ${points[0].y + ((points[1].y - points[0].y) / Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)) * radius}`;
 
   path += ' Z';
+
+  const p0 = points[0];
+  const p1 = points[1];
+  const v0x = p1.x - p0.x;
+  const v0y = p1.y - p0.y;
+  const d0 = Math.sqrt(v0x * v0x + v0y * v0y);
+  const dx0 = v0x / d0;
+  const dy0 = v0y / d0;
+  const start0x = p0.x + dx0 * radius;
+  const start0y = p0.y + dy0 * radius;
+
+  // Replace the simple Z with the final corner
+  path = path.substring(0, path.length - 2); // remove " Z" if I added it above
+  path += ` Q ${p0.x} ${p0.y} ${start0x} ${start0y} Z`;
+
   return path;
 };

--- a/src/shared/components/Block/blockShape.ts
+++ b/src/shared/components/Block/blockShape.ts
@@ -1,0 +1,206 @@
+export type ConnectorType = 'plug' | 'socket';
+export type ConnectorDirection = 'top' | 'right' | 'bottom' | 'left';
+export type ConnectorAlignment = 'start' | 'center' | 'end';
+
+export interface Connector {
+  direction: ConnectorDirection;
+  type: ConnectorType;
+  align?: ConnectorAlignment;
+}
+
+export type BlockConnections = Connector[];
+
+export const createConnectorPath = (
+  x: number,
+  y: number,
+  tabWidth: number,
+  tabHeight: number,
+  type: ConnectorType,
+  direction: ConnectorDirection,
+  inset: number = 6,
+): string => {
+  const isPlug = type === 'plug';
+
+  // Coordinate System for Connector:
+  //
+  //       nx,ny
+  //         ^
+  //         |
+  //   Start *------> dx,dy
+  //         |
+  //       (Inside Block)
+  let dx = 0,
+    dy = 0;
+  let nx = 0,
+    ny = 0;
+
+  if (direction === 'top') {
+    dx = 1;
+    ny = -1;
+  } else if (direction === 'right') {
+    dy = 1;
+    nx = 1;
+  } else if (direction === 'bottom') {
+    dx = -1;
+    ny = 1;
+  } else if (direction === 'left') {
+    dy = -1;
+    nx = -1;
+  }
+
+  const scale = isPlug ? 1 : -1;
+  const vx = nx * scale;
+  const vy = ny * scale;
+
+  const r = inset;
+  const br = inset;
+
+  /*
+   *      P2/C2--------C3/P5    (Top Edge)
+   *      /                \
+   *     /                  \
+   *   P1/C1              P6/C4
+   *   |                      |
+   *   * (Start)              * (Dest)
+   */
+
+  const p1x = x + dx * br + vx * br;
+  const p1y = y + dy * br + vy * br;
+
+  const c1x = x + dx * br;
+  const c1y = y + dy * br;
+
+  const p2x = x + dx * br + vx * (tabHeight - r);
+  const p2y = y + dy * br + vy * (tabHeight - r);
+
+  const c2x = x + dx * br + vx * tabHeight;
+  const c2y = y + dy * br + vy * tabHeight;
+
+  const p3x = x + dx * (br + r) + vx * tabHeight;
+  const p3y = y + dy * (br + r) + vy * tabHeight;
+
+  const p4x = x + dx * (tabWidth - br - r) + vx * tabHeight;
+  const p4y = y + dy * (tabWidth - br - r) + vy * tabHeight;
+
+  const c3x = x + dx * (tabWidth - br) + vx * tabHeight;
+  const c3y = y + dy * (tabWidth - br) + vy * tabHeight;
+
+  const p5x = x + dx * (tabWidth - br) + vx * (tabHeight - r);
+  const p5y = y + dy * (tabWidth - br) + vy * (tabHeight - r);
+
+  const p6x = x + dx * (tabWidth - br) + vx * br;
+  const p6y = y + dy * (tabWidth - br) + vy * br;
+
+  const c4x = x + dx * (tabWidth - br);
+  const c4y = y + dy * (tabWidth - br);
+
+  const destX = x + dx * tabWidth;
+  const destY = y + dy * tabWidth;
+
+  return ` Q ${c1x} ${c1y} ${p1x} ${p1y} L ${p2x} ${p2y} Q ${c2x} ${c2y} ${p3x} ${p3y} L ${p4x} ${p4y} Q ${c3x} ${c3y} ${p5x} ${p5y} L ${p6x} ${p6y} Q ${c4x} ${c4y} ${destX} ${destY}`;
+};
+
+export const createBlockPath = (
+  width: number,
+  height: number,
+  radius: number,
+  tabWidth: number,
+  tabHeight: number,
+  connections: BlockConnections,
+  startX: number = tabHeight,
+  startY: number = tabHeight,
+): string => {
+  const endX = startX + width;
+  const endY = startY + height;
+
+  const ALIGN_MARGIN = 30;
+
+  const getTabStart = (edgeLength: number, align?: ConnectorAlignment) => {
+    switch (align) {
+      case 'start':
+        return ALIGN_MARGIN;
+      case 'end':
+        return edgeLength - tabWidth - ALIGN_MARGIN;
+      case 'center':
+      default:
+        return (edgeLength - tabWidth) / 2;
+    }
+  };
+
+  const connMap: Partial<Record<ConnectorDirection, Connector>> = {};
+  connections.forEach((c) => {
+    connMap[c.direction] = c;
+  });
+
+  // Helper for straight lines and corners
+  //
+  //   (startX, startY)
+  //      *-----------------------* (endX, startY)
+  //      |  Top Edge (L->R)      |
+  //      |                       |
+  // Left |                       | Right
+  // Edge |                       | Edge
+  // (B->T)|                       | (T->B)
+  //      |                       |
+  //      *-----------------------* (endX, endY)
+  //   (startX, endY)  Bottom Edge (R->L)
+  //
+  let path = `M ${startX} ${startY + radius}`;
+
+  path += ` Q ${startX} ${startY} ${startX + radius} ${startY}`;
+  const topConn = connMap.top;
+  if (!topConn) {
+    path += ` L ${endX - radius} ${startY}`;
+  } else {
+    const offset = getTabStart(width, topConn.align);
+    const tabStart = startX + offset;
+
+    path += ` L ${tabStart} ${startY}`;
+    path += createConnectorPath(tabStart, startY, tabWidth, tabHeight, topConn.type, 'top');
+    path += ` L ${endX - radius} ${startY}`;
+  }
+
+  path += ` Q ${endX} ${startY} ${endX} ${startY + radius}`;
+  const rightConn = connMap.right;
+  if (!rightConn) {
+    path += ` L ${endX} ${endY - radius}`;
+  } else {
+    const offset = getTabStart(height, rightConn.align);
+    const tabStart = startY + offset;
+
+    path += ` L ${endX} ${tabStart}`;
+    path += createConnectorPath(endX, tabStart, tabWidth, tabHeight, rightConn.type, 'right');
+    path += ` L ${endX} ${endY - radius}`;
+  }
+
+  path += ` Q ${endX} ${endY} ${endX - radius} ${endY}`;
+  const bottomConn = connMap.bottom;
+  if (!bottomConn) {
+    path += ` L ${startX + radius} ${endY}`;
+  } else {
+    const offset = getTabStart(width, bottomConn.align);
+    const tabVisualStart = startX + offset;
+    const tabVisualEnd = tabVisualStart + tabWidth;
+
+    path += ` L ${tabVisualEnd} ${endY}`;
+    path += createConnectorPath(tabVisualEnd, endY, tabWidth, tabHeight, bottomConn.type, 'bottom');
+    path += ` L ${startX + radius} ${endY}`;
+  }
+
+  path += ` Q ${startX} ${endY} ${startX} ${endY - radius}`;
+  const leftConn = connMap.left;
+  if (!leftConn) {
+    path += ` L ${startX} ${startY + radius}`;
+  } else {
+    const offset = getTabStart(height, leftConn.align);
+    const tabVisualStart = startY + offset;
+    const tabVisualEnd = tabVisualStart + tabWidth;
+
+    path += ` L ${startX} ${tabVisualEnd}`;
+    path += createConnectorPath(startX, tabVisualEnd, tabWidth, tabHeight, leftConn.type, 'left');
+    path += ` L ${startX} ${startY + radius}`;
+  }
+
+  path += ' Z';
+  return path;
+};

--- a/src/shared/components/Block/blockShape.ts
+++ b/src/shared/components/Block/blockShape.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 export interface Point {
   x: number;
   y: number;
@@ -332,4 +334,25 @@ export const createPolygonBlockPath = (
   path += ` Q ${p0.x} ${p0.y} ${start0x} ${start0y} Z`;
 
   return path;
+};
+
+export const useBlockPath = (points: Point[], connectors: Connector[]) => {
+  const RADIUS = 5;
+  const TAB_WIDTH = 42;
+  const TAB_HEIGHT = 16;
+
+  return useMemo(() => {
+    if (!points || points.length === 0) return '';
+    const normalized = normalizePoints(points);
+    return createPolygonBlockPath(normalized, RADIUS, TAB_WIDTH, TAB_HEIGHT, connectors);
+  }, [points, connectors]);
+};
+
+export const normalizePoints = (points: Point[]): Point[] => {
+  if (points.length === 0) return [];
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return points.map((p) => ({ x: p.x - minX, y: p.y - minY }));
 };

--- a/src/shared/components/Block/blockShape.ts
+++ b/src/shared/components/Block/blockShape.ts
@@ -47,6 +47,54 @@ export const convertToPolygonConnections = (connections: BlockConnections): Conn
   return polygonConnections;
 };
 
+const ALIGN_MARGIN = 30;
+
+/**
+ * 폴리곤의 특정 edge에 있는 커넥터의 중심점을 계산
+ * @param points - 폴리곤 꼭짓점 배열
+ * @param connector - 커넥터 정보 (edgeIndex, align)
+ * @param tabWidth - 탭의 너비
+ * @returns 커넥터 중심점 좌표
+ */
+export const getConnectorCenter = (points: Point[], connector: Connector, tabWidth: number): Point | null => {
+  if (points.length < 3) return null;
+
+  const { edgeIndex, align = 'center' } = connector;
+  if (edgeIndex < 0 || edgeIndex >= points.length) return null;
+
+  const p1 = points[edgeIndex];
+  const p2 = points[(edgeIndex + 1) % points.length];
+
+  // edge 방향 벡터
+  const vx = p2.x - p1.x;
+  const vy = p2.y - p1.y;
+  const edgeLength = Math.sqrt(vx * vx + vy * vy);
+
+  if (edgeLength === 0) return null;
+
+  // 정규화된 방향
+  const dx = vx / edgeLength;
+  const dy = vy / edgeLength;
+
+  // 탭 시작 위치 계산 (createPolygonBlockPath와 동일한 로직)
+  let tabStartDist: number;
+  if (align === 'start') {
+    tabStartDist = ALIGN_MARGIN;
+  } else if (align === 'end') {
+    tabStartDist = edgeLength - tabWidth - ALIGN_MARGIN;
+  } else {
+    tabStartDist = (edgeLength - tabWidth) / 2;
+  }
+
+  // 탭 중심까지의 거리
+  const tabCenterDist = tabStartDist + tabWidth / 2;
+
+  return {
+    x: p1.x + dx * tabCenterDist,
+    y: p1.y + dy * tabCenterDist,
+  };
+};
+
 export const createConnectorPath = (
   x: number,
   y: number,
@@ -156,7 +204,6 @@ export const createPolygonBlockPath = (
   if (points.length < 3) return '';
 
   let path = '';
-  const ALIGN_MARGIN = 30;
 
   // Map connectors to edges by index
   const connMap: Record<number, Connector> = {};
@@ -221,8 +268,6 @@ export const createPolygonBlockPath = (
 
   path += ` Q ${points[0].x} ${points[0].y} ${points[0].x + ((points[1].x - points[0].x) / Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)) * radius} ${points[0].y + ((points[1].y - points[0].y) / Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y)) * radius}`;
 
-  path += ' Z';
-
   const p0 = points[0];
   const p1 = points[1];
   const v0x = p1.x - p0.x;
@@ -233,8 +278,6 @@ export const createPolygonBlockPath = (
   const start0x = p0.x + dx0 * radius;
   const start0y = p0.y + dy0 * radius;
 
-  // Replace the simple Z with the final corner
-  path = path.substring(0, path.length - 2); // remove " Z" if I added it above
   path += ` Q ${p0.x} ${p0.y} ${start0x} ${start0y} Z`;
 
   return path;

--- a/src/shared/components/Block/blockShape.ts
+++ b/src/shared/components/Block/blockShape.ts
@@ -114,6 +114,38 @@ export const getBoundingBox = (points: Point[]): { w: number; h: number } => {
   return { w: maxX - minX, h: maxY - minY };
 };
 
+export type EdgeDirection = 'up' | 'down' | 'left' | 'right';
+
+// 엣지의 outward normal 방향 계산 (시계방향으로 엣지를 그린다는 것을 가정함; 90도 각도 도형만 전제)
+export const getEdgeDirection = (points: Point[], edgeIndex: number): EdgeDirection | null => {
+  if (points.length < 2 || edgeIndex < 0 || edgeIndex >= points.length) return null;
+
+  const p1 = points[edgeIndex];
+  const p2 = points[(edgeIndex + 1) % points.length];
+
+  const dx = p2.x - p1.x;
+  const dy = p2.y - p1.y;
+
+  // dx 또는 dy 중 하나만 0이 아니어야 함
+  if (dy === 0 && dx > 0) return 'up';
+  if (dx === 0 && dy > 0) return 'right';
+  if (dy === 0 && dx < 0) return 'down';
+  if (dx === 0 && dy < 0) return 'left';
+
+  console.error('getEdgeDirection은 사각형-like 도형만 지원합니다.');
+  return null;
+};
+
+// 두 방향이 서로 반대인지 확인
+export const areOppositeDirections = (dir1: EdgeDirection, dir2: EdgeDirection): boolean => {
+  return (
+    (dir1 === 'up' && dir2 === 'down') ||
+    (dir1 === 'down' && dir2 === 'up') ||
+    (dir1 === 'left' && dir2 === 'right') ||
+    (dir1 === 'right' && dir2 === 'left')
+  );
+};
+
 export const createConnectorPath = (
   x: number,
   y: number,

--- a/src/shared/stores/blockTemplateStore.ts
+++ b/src/shared/stores/blockTemplateStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { Block } from '@/feature/block/blockBuild/types/block';
 import { removeBlock } from '@/feature/block/blockBuild/utils/commit';
+import { createRectPoints } from '@/shared/components/Block/blockShape';
 
 const START_ID = 0;
 
@@ -12,9 +13,8 @@ const START_BLOCK: Block = {
   duration: '',
   x: 44,
   y: 76,
-  w: 186,
-  h: 87,
-  connectors: { input: null, output: 'right' },
+  points: createRectPoints(186, 87),
+  connectors: [{ type: 'socket', edgeIndex: 1, align: 'center' }],
   connectedTo: null,
   connectedFrom: null,
 };

--- a/src/shared/ui/icon/registry.ts
+++ b/src/shared/ui/icon/registry.ts
@@ -1,8 +1,14 @@
 import Arrow from '@/shared/assets/splash/icon-arrow.svg?react';
+import Clock from '@/feature/block/blockBuild/assets/edit-icon-clock.svg?react';
+import DragHandle from '@/shared/assets/icon-drag-handle.svg?react';
+import Food from '@/shared/assets/preference/icon-preference-food.svg?react';
 import X from '@/shared/assets/icon-x.svg?react';
 
 export const iconRegistry = {
   arrow: Arrow,
+  clock: Clock,
+  dragHandle: DragHandle,
+  food: Food,
   x: X,
 } as const;
 


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #31 

### ✨️ 작업 내용

블록 에디터에 블록 디자인을 적용합니다.
- 기존의 사각형 구현체를 디자인상의 블록을 적용하기 위해 폴리곤을 사용하도록 했습니다.

### 💭 코멘트
- 이미 작업 범위가 너무 큰 것 같아서 시간별로 블록 디자인을 다르게 적용하는 건 #46 으로 분리했습니다.
  - 다른 duration을 가지는 블록은 `TestLayout`에서 확인할 수 있습니다.

### 📸 구현 결과


https://github.com/user-attachments/assets/03ff49ab-1066-4be3-8aec-ea40a3479f27

왜인지는 모르겠지만 영상이 조금 어둡게 나오는군요...

<img width="535" height="368" alt="image" src="https://github.com/user-attachments/assets/da063d33-a587-4190-9e54-3b48216f7f0a" />
