### PR TITLE
[Feat] 마이페이지 API

### DIFF
--- a/src/feature/mypage/apis/favorite.ts
+++ b/src/feature/mypage/apis/favorite.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '@/shared/apis/axios';
+
+export const putFavorite = async (templateId: number): Promise<void> => {
+  try {
+    await axiosInstance.put(`/templates/${templateId}/favorite`);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const deleteFavorite = async (templateId: number): Promise<void> => {
+  try {
+    await axiosInstance.delete(`/templates/${templateId}/favorite`);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/feature/mypage/apis/mypage.ts
+++ b/src/feature/mypage/apis/mypage.ts
@@ -1,0 +1,12 @@
+import { axiosInstance } from '@/shared/apis/axios';
+import type { ResponseMyPageDto } from '../types/mypage.type';
+
+export const getMyPage = async (): Promise<ResponseMyPageDto> => {
+  try {
+    const { data } = await axiosInstance.get<ResponseMyPageDto>('/members/me/mypage');
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/feature/mypage/apis/mypage.ts
+++ b/src/feature/mypage/apis/mypage.ts
@@ -1,9 +1,19 @@
 import { axiosInstance } from '@/shared/apis/axios';
-import type { ResponseMyPageDto } from '../types/mypage.type';
+import type { RequestUpdateMyProfileDto, ResponseMyPageDto, ResponseUpdateMyProfileDto } from '../types/mypage.type';
 
 export const getMyPage = async (): Promise<ResponseMyPageDto> => {
   try {
     const { data } = await axiosInstance.get<ResponseMyPageDto>('/members/me/mypage');
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const patchMyProfile = async (request: RequestUpdateMyProfileDto): Promise<ResponseUpdateMyProfileDto> => {
+  try {
+    const { data } = await axiosInstance.patch<ResponseUpdateMyProfileDto>('/members/me/profile', request);
     return data;
   } catch (error) {
     console.error(error);

--- a/src/feature/mypage/components/Dashboard.tsx
+++ b/src/feature/mypage/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import SectionHeader from './SectionHeader';
 import SettingsSection from './SettingsSection';
 import StatusCard from './StatusCard';
 import { useMyPageQuery } from '../hooks/useMyPageQuery';
+import { useFavoriteMutation } from '../hooks/useFavoriteMutation';
 import type { VlockDto, CreatedTemplateDto } from '../types/mypage.type';
 
 // Vlock을 ActivityList 형식으로 변환
@@ -32,10 +33,13 @@ const formatTemplateForActivity = (template: CreatedTemplateDto) => ({
 
 const Dashboard = () => {
   const { data: myPageData, isLoading, isError } = useMyPageQuery();
+  const { toggleFavorite } = useFavoriteMutation();
 
-  // TODO: /templates/{templateId}/favorite
   const handleToggleFavorite = (id: string) => {
-    console.log('Toggle favorite for template:', id);
+    const template = myPageData?.recent.createdTemplates.find((t) => t.templateId === Number(id));
+    if (template) {
+      toggleFavorite(template.templateId, template.isFavorite);
+    }
   };
 
   if (isLoading) {

--- a/src/feature/mypage/components/Dashboard.tsx
+++ b/src/feature/mypage/components/Dashboard.tsx
@@ -2,12 +2,15 @@ import PuzzleIcon from '@/shared/assets/icon-puzzle.svg?react';
 import StarIcon from '@/shared/assets/icon-star.svg?react';
 import TemplateIcon from '@/shared/assets/icon-template.svg?react';
 import ActivityList from './ActivityList';
+import type { InterestTheme } from './InterestThemeSection';
 import ProfileHeader from './ProfileHeader';
 import SectionHeader from './SectionHeader';
 import SettingsSection from './SettingsSection';
 import StatusCard from './StatusCard';
+import type { TravelStyle } from './TravelStyleSection';
 import { useMyPageQuery } from '../hooks/useMyPageQuery';
 import { useFavoriteMutation } from '../hooks/useFavoriteMutation';
+import { useUpdateMyProfileMutation } from '../hooks/useUpdateMyProfileMutation';
 import type { VlockDto, CreatedTemplateDto } from '../types/mypage.type';
 
 // Vlock을 ActivityList 형식으로 변환
@@ -31,15 +34,90 @@ const formatTemplateForActivity = (template: CreatedTemplateDto) => ({
   isFavorite: template.isFavorite,
 });
 
+const TRAVEL_STYLE_TO_ID: Record<TravelStyle, number> = {
+  free: 1,
+  healing: 2,
+  food: 3,
+  other: 4,
+  activity: 5,
+  accommodation: 6,
+};
+
+const TRAVEL_STYLE_ID_TO_KEY: Partial<Record<number, TravelStyle>> = {
+  1: 'free',
+  2: 'healing',
+  3: 'food',
+  4: 'other',
+  5: 'activity',
+  6: 'accommodation',
+};
+
+const INTEREST_THEME_TO_ID: Record<InterestTheme, number> = {
+  nature: 1,
+  culture: 2,
+  food: 3,
+  healing: 4,
+  activity: 5,
+  local: 6,
+};
+
+const INTEREST_THEME_ID_TO_KEY: Partial<Record<number, InterestTheme>> = {
+  1: 'nature',
+  2: 'culture',
+  3: 'food',
+  4: 'healing',
+  5: 'activity',
+  6: 'local',
+};
+
+const toTravelStyleKeys = (styleIds: number[]): TravelStyle[] => {
+  return styleIds
+    .map((styleId) => TRAVEL_STYLE_ID_TO_KEY[styleId])
+    .filter((style): style is TravelStyle => style !== undefined);
+};
+
+const toInterestThemeKeys = (themeIds: number[]): InterestTheme[] => {
+  return themeIds
+    .map((themeId) => INTEREST_THEME_ID_TO_KEY[themeId])
+    .filter((theme): theme is InterestTheme => theme !== undefined);
+};
+
+const toTravelStyleIds = (styles: TravelStyle[]): number[] => {
+  return [...new Set(styles.map((style) => TRAVEL_STYLE_TO_ID[style]))];
+};
+
+const toInterestThemeIds = (themes: InterestTheme[]): number[] => {
+  return [...new Set(themes.map((theme) => INTEREST_THEME_TO_ID[theme]))];
+};
+
 const Dashboard = () => {
   const { data: myPageData, isLoading, isError } = useMyPageQuery();
   const { toggleFavorite } = useFavoriteMutation();
+  const { updateMyProfile, isPending: isProfileUpdating } = useUpdateMyProfileMutation({
+    onError: (error) => {
+      console.error('Failed to save settings:', error);
+    },
+  });
 
   const handleToggleFavorite = (id: string) => {
     const template = myPageData?.recent.createdTemplates.find((t) => t.templateId === Number(id));
     if (template) {
       toggleFavorite(template.templateId, template.isFavorite);
     }
+  };
+
+  const handleSaveSettings = (data: {
+    nickname: string;
+    bio: string;
+    travelStyles: TravelStyle[];
+    interestThemes: InterestTheme[];
+  }) => {
+    updateMyProfile({
+      nickname: data.nickname,
+      introduction: data.bio,
+      preferredTravelStyleIds: toTravelStyleIds(data.travelStyles),
+      preferredTravelThemeIds: toInterestThemeIds(data.interestThemes),
+    });
   };
 
   if (isLoading) {
@@ -54,7 +132,7 @@ const Dashboard = () => {
 
   return (
     <div className="px-6 py-12">
-      <ProfileHeader />
+      <ProfileHeader nickname={myPageData.nickname} introduction={myPageData.introduction} />
       <div className="flex gap-5">
         <StatusCard icon={<PuzzleIcon />} label="Vlocks" count={myPageData.counts.vlockCount} />
         <StatusCard icon={<TemplateIcon />} label="템플릿" count={myPageData.counts.templateCount} />
@@ -84,7 +162,10 @@ const Dashboard = () => {
           initialNickname={myPageData.nickname}
           email="your@email.com"
           initialBio={myPageData.introduction || ''}
-          onSave={(data) => console.log('Settings saved:', data)}
+          initialTravelStyles={toTravelStyleKeys(myPageData.preferredTravelStyleIds)}
+          initialInterestThemes={toInterestThemeKeys(myPageData.preferredTravelThemeIds)}
+          isSaving={isProfileUpdating}
+          onSave={handleSaveSettings}
         />
       </div>
     </div>

--- a/src/feature/mypage/components/Dashboard.tsx
+++ b/src/feature/mypage/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import PuzzleIcon from '@/shared/assets/icon-puzzle.svg?react';
 import StarIcon from '@/shared/assets/icon-star.svg?react';
 import TemplateIcon from '@/shared/assets/icon-template.svg?react';
+import { REGION_MAP, type RegionId } from '@/shared/constants/destinationCity';
 import ActivityList from './ActivityList';
 import type { InterestTheme } from './InterestThemeSection';
 import ProfileHeader from './ProfileHeader';
@@ -13,11 +14,13 @@ import { useFavoriteMutation } from '../hooks/useFavoriteMutation';
 import { useUpdateMyProfileMutation } from '../hooks/useUpdateMyProfileMutation';
 import type { VlockDto, CreatedTemplateDto } from '../types/mypage.type';
 
+const getRegionName = (regionId: number) => REGION_MAP[regionId as RegionId]?.name.korean ?? '지역 정보 없음';
+
 // Vlock을 ActivityList 형식으로 변환
 const formatVlockForActivity = (vlock: VlockDto) => ({
   id: String(vlock.vlockId),
-  title: vlock.name,
-  location: vlock.city,
+  title: vlock.vlockName,
+  location: getRegionName(vlock.regionId),
   date:
     new Date(vlock.createdAt).toLocaleDateString('ko-KR', {
       year: 'numeric',
@@ -29,9 +32,9 @@ const formatVlockForActivity = (vlock: VlockDto) => ({
 // Template을 ActivityList 형식으로 변환
 const formatTemplateForActivity = (template: CreatedTemplateDto) => ({
   id: String(template.templateId),
-  title: template.title,
-  description: template.city,
-  isFavorite: template.isFavorite,
+  title: template.templateTitle,
+  description: getRegionName(template.regionId),
+  isFavorite: template.favorite,
 });
 
 const TRAVEL_STYLE_TO_ID: Record<TravelStyle, number> = {
@@ -100,9 +103,10 @@ const Dashboard = () => {
   });
 
   const handleToggleFavorite = (id: string) => {
-    const template = myPageData?.recent.createdTemplates.find((t) => t.templateId === Number(id));
+    const recentTemplates = myPageData?.recent.myPageRecentTemplates ?? [];
+    const template = recentTemplates.find((t) => t.templateId === Number(id));
     if (template) {
-      toggleFavorite(template.templateId, template.isFavorite);
+      toggleFavorite(template.templateId, template.favorite);
     }
   };
 
@@ -128,11 +132,17 @@ const Dashboard = () => {
     return <div className="px-6 py-12 text-center text-red-500">데이터를 불러오는데 실패했습니다.</div>;
   }
 
-  const recentVlocks = myPageData.recent.createdVlocks.map(formatVlockForActivity);
+  const recentVlockSource = myPageData.recent.myPageRecentVlocks;
+  const recentTemplateSource = myPageData.recent.myPageRecentTemplates;
+  const recentVlocks = recentVlockSource.map(formatVlockForActivity);
 
   return (
     <div className="px-6 py-12">
-      <ProfileHeader nickname={myPageData.nickname} introduction={myPageData.introduction} />
+      <ProfileHeader
+        nickname={myPageData.nickname}
+        introduction={myPageData.introduction}
+        profileImageUrl={myPageData.profileImageUrl}
+      />
       <div className="flex gap-5">
         <StatusCard icon={<PuzzleIcon />} label="Vlocks" count={myPageData.counts.vlockCount} />
         <StatusCard icon={<TemplateIcon />} label="템플릿" count={myPageData.counts.templateCount} />
@@ -149,8 +159,8 @@ const Dashboard = () => {
         </div>
         <div className="flex-1">
           <ActivityList
-            sectionTitle="최근 사용한 탬플릿"
-            activities={myPageData.recent.createdTemplates.map(formatTemplateForActivity)}
+            sectionTitle="최근 사용한 템플릿"
+            activities={recentTemplateSource.map(formatTemplateForActivity)}
             showStar
             onToggleFavorite={handleToggleFavorite}
           />
@@ -160,7 +170,7 @@ const Dashboard = () => {
       <div className="mt-20">
         <SettingsSection
           initialNickname={myPageData.nickname}
-          email="your@email.com"
+          email={myPageData.email}
           initialBio={myPageData.introduction || ''}
           initialTravelStyles={toTravelStyleKeys(myPageData.preferredTravelStyleIds)}
           initialInterestThemes={toInterestThemeKeys(myPageData.preferredTravelThemeIds)}

--- a/src/feature/mypage/components/Dashboard.tsx
+++ b/src/feature/mypage/components/Dashboard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import PuzzleIcon from '@/shared/assets/icon-puzzle.svg?react';
 import StarIcon from '@/shared/assets/icon-star.svg?react';
 import TemplateIcon from '@/shared/assets/icon-template.svg?react';
@@ -7,77 +6,55 @@ import ProfileHeader from './ProfileHeader';
 import SectionHeader from './SectionHeader';
 import SettingsSection from './SettingsSection';
 import StatusCard from './StatusCard';
+import { useMyPageQuery } from '../hooks/useMyPageQuery';
+import type { VlockDto, CreatedTemplateDto } from '../types/mypage.type';
 
-const recentlyCreatedBlocks = [
-  {
-    id: '1',
-    title: '제주도 3박 4일 여행',
-    location: '부산',
-    date: '2025.12.28 수정됨',
-  },
-  {
-    id: '2',
-    title: '부산 먹방 코스',
-    location: '부산',
-    date: '2025.12.20 수정됨',
-  },
-  {
-    id: '3',
-    title: '강릉 겨울 바다',
-    location: '강릉',
-    date: '2025.12.15 수정됨',
-  },
-  {
-    id: '4',
-    title: '춘천 주말 여행',
-    location: '춘천',
-    date: '2025.12.02 수정됨',
-  },
-];
+// Vlock을 ActivityList 형식으로 변환
+const formatVlockForActivity = (vlock: VlockDto) => ({
+  id: String(vlock.vlockId),
+  title: vlock.name,
+  location: vlock.city,
+  date:
+    new Date(vlock.createdAt).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }) + ' 수정됨',
+});
 
-const initialTemplates = [
-  {
-    id: '5',
-    title: '제주도 렌트카 여행 템플릿',
-    description: '주차 가능한 여행지 추천 모음',
-    isFavorite: false,
-  },
-  {
-    id: '6',
-    title: '2박 3일 서울 가족여행',
-    description: '부모님 모시고 가기 좋은 코스',
-    isFavorite: true,
-  },
-  {
-    id: '7',
-    title: '유럽 배낭여행 체크리스트',
-    description: '필수 준비물부터 생활 꿀팁까지',
-    isFavorite: false,
-  },
-  {
-    id: '8',
-    title: '국내 캠핑 준비물',
-    description: '초보 캠핑러를 위한 가이드',
-    isFavorite: false,
-  },
-];
+// Template을 ActivityList 형식으로 변환
+const formatTemplateForActivity = (template: CreatedTemplateDto) => ({
+  id: String(template.templateId),
+  title: template.title,
+  description: template.city,
+  isFavorite: template.isFavorite,
+});
 
 const Dashboard = () => {
-  const [templates, setTemplates] = useState(initialTemplates);
+  const { data: myPageData, isLoading, isError } = useMyPageQuery();
 
+  // TODO: /templates/{templateId}/favorite
   const handleToggleFavorite = (id: string) => {
-    setTemplates((prev) =>
-      prev.map((template) => (template.id === id ? { ...template, isFavorite: !template.isFavorite } : template)),
-    );
+    console.log('Toggle favorite for template:', id);
   };
+
+  if (isLoading) {
+    return <div className="px-6 py-12 text-center">로딩 중...</div>;
+  }
+
+  if (isError || !myPageData) {
+    return <div className="px-6 py-12 text-center text-red-500">데이터를 불러오는데 실패했습니다.</div>;
+  }
+
+  const recentVlocks = myPageData.recent.createdVlocks.map(formatVlockForActivity);
 
   return (
     <div className="px-6 py-12">
       <ProfileHeader />
       <div className="flex gap-5">
-        <StatusCard icon={<PuzzleIcon />} label="Vlocks" count={24} />
-        <StatusCard icon={<TemplateIcon />} label="템플릿" count={8} />
-        <StatusCard icon={<StarIcon />} label="즐겨찾기" count={12} />
+        <StatusCard icon={<PuzzleIcon />} label="Vlocks" count={myPageData.counts.vlockCount} />
+        <StatusCard icon={<TemplateIcon />} label="템플릿" count={myPageData.counts.templateCount} />
+        <StatusCard icon={<StarIcon />} label="즐겨찾기" count={myPageData.counts.starCount} />
       </div>
 
       <div className="mt-20">
@@ -86,12 +63,12 @@ const Dashboard = () => {
 
       <div className="flex gap-5 mt-7">
         <div className="flex-1">
-          <ActivityList sectionTitle="최근 생성 블록" activities={recentlyCreatedBlocks} />
+          <ActivityList sectionTitle="최근 생성 블록" activities={recentVlocks} />
         </div>
         <div className="flex-1">
           <ActivityList
             sectionTitle="최근 사용한 탬플릿"
-            activities={templates}
+            activities={myPageData.recent.createdTemplates.map(formatTemplateForActivity)}
             showStar
             onToggleFavorite={handleToggleFavorite}
           />
@@ -100,9 +77,9 @@ const Dashboard = () => {
 
       <div className="mt-20">
         <SettingsSection
-          initialNickname="디모"
+          initialNickname={myPageData.nickname}
           email="your@email.com"
-          initialBio="한줄소개 내용이 이곳에 들어갑니다"
+          initialBio={myPageData.introduction || ''}
           onSave={(data) => console.log('Settings saved:', data)}
         />
       </div>

--- a/src/feature/mypage/components/ProfileHeader.tsx
+++ b/src/feature/mypage/components/ProfileHeader.tsx
@@ -2,10 +2,12 @@ import SettingsIcon from '@/shared/assets/icon-settings.svg?react';
 import clsx from 'clsx';
 
 interface ProfileHeaderProps {
+  nickname: string;
+  introduction?: string | null;
   className?: string;
 }
 
-const ProfileHeader = ({ className }: ProfileHeaderProps) => {
+const ProfileHeader = ({ nickname, introduction, className }: ProfileHeaderProps) => {
   return (
     <div className={clsx('flex items-start justify-between w-full mb-12', className)}>
       <div className="flex items-center gap-8">
@@ -19,8 +21,8 @@ const ProfileHeader = ({ className }: ProfileHeaderProps) => {
         </div>
 
         <div className="flex flex-col gap-2">
-          <h1 className="h1 text-base-color-0">유저 닉네임</h1>
-          <p className="h5 text-base-color-2">한줄소개 내용이 이곳에 들어갑니다</p>
+          <h1 className="h1 text-base-color-0">{nickname}</h1>
+          <p className="h5 text-base-color-2">{introduction || '소개가 없습니다.'}</p>
         </div>
       </div>
 

--- a/src/feature/mypage/components/ProfileHeader.tsx
+++ b/src/feature/mypage/components/ProfileHeader.tsx
@@ -4,20 +4,25 @@ import clsx from 'clsx';
 interface ProfileHeaderProps {
   nickname: string;
   introduction?: string | null;
+  profileImageUrl?: string | null;
   className?: string;
 }
 
-const ProfileHeader = ({ nickname, introduction, className }: ProfileHeaderProps) => {
+const ProfileHeader = ({ nickname, introduction, profileImageUrl, className }: ProfileHeaderProps) => {
   return (
     <div className={clsx('flex items-start justify-between w-full mb-12', className)}>
       <div className="flex items-center gap-8">
         {/* Avatar */}
         <div className="relative w-45 h-45 rounded-full bg-base-color-6 flex items-center justify-center border-8 border-base-color-6 overflow-hidden">
-          <img
-            src="" // TODO: 이미지
-            alt="Avatar"
-            className={clsx('bg-base-color-4 w-full h-full')}
-          />
+          {profileImageUrl ? (
+            <img
+              src={profileImageUrl}
+              alt={`${nickname} 프로필 이미지`}
+              className={clsx('bg-base-color-4 w-full h-full')}
+            />
+          ) : (
+            <div className="bg-base-color-4 w-full h-full" />
+          )}
         </div>
 
         <div className="flex flex-col gap-2">

--- a/src/feature/mypage/components/SettingsSection.tsx
+++ b/src/feature/mypage/components/SettingsSection.tsx
@@ -17,8 +17,11 @@ interface SettingsSectionProps {
     travelStyles: TravelStyle[];
     interestThemes: InterestTheme[];
   }) => void;
+  isSaving?: boolean;
   className?: string;
 }
+
+const MAX_SELECTABLE_PREFERENCES = 2;
 
 const SettingsSection = ({
   initialNickname = '',
@@ -27,6 +30,7 @@ const SettingsSection = ({
   initialTravelStyles = [],
   initialInterestThemes = [],
   onSave,
+  isSaving = false,
   className,
 }: SettingsSectionProps) => {
   const [nickname, setNickname] = useState(initialNickname);
@@ -35,11 +39,31 @@ const SettingsSection = ({
   const [interestThemes, setInterestThemes] = useState<InterestTheme[]>(initialInterestThemes);
 
   const handleToggleTravelStyle = (style: TravelStyle) => {
-    setTravelStyles((prev) => (prev.includes(style) ? prev.filter((s) => s !== style) : [...prev, style]));
+    setTravelStyles((prev) => {
+      if (prev.includes(style)) {
+        return prev.filter((s) => s !== style);
+      }
+
+      if (prev.length >= MAX_SELECTABLE_PREFERENCES) {
+        return prev;
+      }
+
+      return [...prev, style];
+    });
   };
 
   const handleToggleInterestTheme = (theme: InterestTheme) => {
-    setInterestThemes((prev) => (prev.includes(theme) ? prev.filter((t) => t !== theme) : [...prev, theme]));
+    setInterestThemes((prev) => {
+      if (prev.includes(theme)) {
+        return prev.filter((t) => t !== theme);
+      }
+
+      if (prev.length >= MAX_SELECTABLE_PREFERENCES) {
+        return prev;
+      }
+
+      return [...prev, theme];
+    });
   };
 
   const handleSave = () => {
@@ -83,9 +107,10 @@ const SettingsSection = ({
         <div className="flex justify-end mt-10">
           <button
             type="button"
+            disabled={isSaving}
             onClick={handleSave}
-            className="h10 w-[217px] h-[65px] bg-primary-color text-base-color-6 rounded-[15px] cursor-pointer hover:opacity-90 transition-opacity">
-            변경사항 저장
+            className="h10 w-[217px] h-[65px] bg-primary-color text-base-color-6 rounded-[15px] cursor-pointer hover:opacity-90 transition-opacity disabled:opacity-60 disabled:cursor-not-allowed">
+            {isSaving ? '저장 중...' : '변경사항 저장'}
           </button>
         </div>
       </div>

--- a/src/feature/mypage/hooks/useFavoriteMutation.ts
+++ b/src/feature/mypage/hooks/useFavoriteMutation.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { putFavorite, deleteFavorite } from '../apis/favorite';
+import type { AxiosError } from 'axios';
+
+interface UseFavoriteMutationOptions {
+  onSuccess?: () => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useFavoriteMutation = (options?: UseFavoriteMutationOptions) => {
+  const queryClient = useQueryClient();
+
+  const addFavorite = useMutation<void, AxiosError, number>({
+    mutationFn: putFavorite,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['mypage'] });
+      options?.onSuccess?.();
+    },
+    onError: (error) => {
+      console.error('Failed to add favorite:', error);
+      options?.onError?.(error);
+    },
+  });
+
+  const removeFavorite = useMutation<void, AxiosError, number>({
+    mutationFn: deleteFavorite,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['mypage'] });
+      options?.onSuccess?.();
+    },
+    onError: (error) => {
+      console.error('Failed to remove favorite:', error);
+      options?.onError?.(error);
+    },
+  });
+
+  const toggleFavorite = (templateId: number, isFavorite: boolean) => {
+    if (isFavorite) {
+      removeFavorite.mutate(templateId);
+    } else {
+      addFavorite.mutate(templateId);
+    }
+  };
+
+  return {
+    toggleFavorite,
+    isPending: addFavorite.isPending || removeFavorite.isPending,
+  };
+};

--- a/src/feature/mypage/hooks/useMyPageQuery.ts
+++ b/src/feature/mypage/hooks/useMyPageQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyPage } from '../apis/mypage';
+import type { MyPage } from '../types/mypage.type';
+
+export const useMyPageQuery = () => {
+  return useQuery<MyPage>({
+    queryKey: ['mypage'],
+    queryFn: async () => {
+      const response = await getMyPage();
+      return response.data;
+    },
+  });
+};

--- a/src/feature/mypage/hooks/useUpdateMyProfileMutation.ts
+++ b/src/feature/mypage/hooks/useUpdateMyProfileMutation.ts
@@ -1,0 +1,30 @@
+import type { AxiosError } from 'axios';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchMyProfile } from '../apis/mypage';
+import type { RequestUpdateMyProfileDto, ResponseUpdateMyProfileDto } from '../types/mypage.type';
+
+interface UseUpdateMyProfileMutationOptions {
+  onSuccess?: (data: ResponseUpdateMyProfileDto) => void;
+  onError?: (error: AxiosError) => void;
+}
+
+export const useUpdateMyProfileMutation = (options?: UseUpdateMyProfileMutationOptions) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation<ResponseUpdateMyProfileDto, AxiosError, RequestUpdateMyProfileDto>({
+    mutationFn: patchMyProfile,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['mypage'] });
+      options?.onSuccess?.(data);
+    },
+    onError: (error) => {
+      console.error('Failed to update profile:', error);
+      options?.onError?.(error);
+    },
+  });
+
+  return {
+    updateMyProfile: mutation.mutate,
+    isPending: mutation.isPending,
+  };
+};

--- a/src/feature/mypage/types/mypage.type.ts
+++ b/src/feature/mypage/types/mypage.type.ts
@@ -1,0 +1,35 @@
+import type { SuccessPayload } from '@/shared/types/common';
+import type { Vlock } from '@/shared/types/vlock';
+
+export type { Vlock as VlockDto };
+
+export interface CreatedTemplateDto {
+  templateId: number;
+  title: string;
+  city: string;
+  createdAt: string;
+  isFavorite: boolean;
+}
+
+export interface CountsDto {
+  vlockCount: number;
+  templateCount: number;
+  starCount: number;
+}
+
+export interface RecentDto {
+  createdVlocks: Vlock[];
+  createdTemplates: CreatedTemplateDto[];
+}
+
+export interface MyPage {
+  memberId: number;
+  nickname: string;
+  introduction: string;
+  preferredTravelStyleIds: number[];
+  preferredTravelThemeIds: number[];
+  counts: CountsDto;
+  recent: RecentDto;
+}
+
+export type ResponseMyPageDto = SuccessPayload<MyPage>;

--- a/src/feature/mypage/types/mypage.type.ts
+++ b/src/feature/mypage/types/mypage.type.ts
@@ -32,4 +32,20 @@ export interface MyPage {
   recent: RecentDto;
 }
 
+export interface RequestUpdateMyProfileDto {
+  nickname: string;
+  introduction: string;
+  preferredTravelStyleIds: number[];
+  preferredTravelThemeIds: number[];
+}
+
+export interface UpdatedMyProfile {
+  memberId: number;
+  nickname: string;
+  introduction: string;
+  preferredTravelStyleIds: number[];
+  preferredTravelThemeIds: number[];
+}
+
 export type ResponseMyPageDto = SuccessPayload<MyPage>;
+export type ResponseUpdateMyProfileDto = SuccessPayload<UpdatedMyProfile>;

--- a/src/feature/mypage/types/mypage.type.ts
+++ b/src/feature/mypage/types/mypage.type.ts
@@ -1,14 +1,18 @@
 import type { SuccessPayload } from '@/shared/types/common';
-import type { Vlock } from '@/shared/types/vlock';
 
-export type { Vlock as VlockDto };
+export interface VlockDto {
+  vlockId: number;
+  vlockName: string;
+  regionId: number;
+  createdAt: string;
+}
 
 export interface CreatedTemplateDto {
   templateId: number;
-  title: string;
-  city: string;
+  templateTitle: string;
+  regionId: number;
   createdAt: string;
-  isFavorite: boolean;
+  favorite: boolean;
 }
 
 export interface CountsDto {
@@ -18,14 +22,16 @@ export interface CountsDto {
 }
 
 export interface RecentDto {
-  createdVlocks: Vlock[];
-  createdTemplates: CreatedTemplateDto[];
+  myPageRecentVlocks: VlockDto[];
+  myPageRecentTemplates: CreatedTemplateDto[];
 }
 
 export interface MyPage {
   memberId: number;
   nickname: string;
   introduction: string;
+  profileImageUrl: string;
+  email: string;
   preferredTravelStyleIds: number[];
   preferredTravelThemeIds: number[];
   counts: CountsDto;

--- a/src/shared/types/vlock.ts
+++ b/src/shared/types/vlock.ts
@@ -1,0 +1,6 @@
+export interface Vlock {
+  vlockId: number;
+  name: string;
+  city: string;
+  createdAt: string;
+}


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #66 

### ✨️ 작업 내용

마이페이지 API를 연결합니다

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

오늘 (2월 11일) 밤까지 첨부하겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 개인 대시보드에 프로필(닉네임, 소개, 프로필 이미지), 최근 활동 및 통계가 실시간으로 표시됩니다.
  * 템플릿을 즐겨찾기 추가/제거할 수 있습니다(토글).
  * 닉네임·소개·여행 스타일·관심사 편집 및 저장 기능이 추가되었습니다(선택 항목 최대 2개 제한).
  * 데이터 로딩 및 오류 상태 처리가 UI에 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->