### PR TITLE
[Feat] 마이페이지 모달 연결 및 디자인 수정

### DIFF
--- a/src/feature/mypage/components/InterestThemeSection.tsx
+++ b/src/feature/mypage/components/InterestThemeSection.tsx
@@ -1,8 +1,10 @@
 import clsx from 'clsx';
-import TreeIcon from '@/shared/assets/icon-tree.svg?react';
-import BuildingIcon from '@/shared/assets/icon-building.svg?react';
-import UtensilsIcon from '@/shared/assets/icon-utensils.svg?react';
-import ActivityIcon from '@/shared/assets/icon-activity.svg?react';
+import TreeIcon from '@assets/preference/icon-preference-nature.svg?react';
+import BuildingIcon from '@assets/preference/icon-preference-culture.svg?react';
+import LocalIcon from '@assets/preference/icon-preference-local.svg?react';
+import UtensilsIcon from '@assets/preference/icon-preference-food.svg?react';
+import HealingIcon from '@assets/preference/icon-preference-healing.svg?react';
+import ActivityIcon from '@assets/preference/icon-preference-activity.svg?react';
 import StyleCard from './StyleCard';
 
 export type InterestTheme = 'nature' | 'culture' | 'food' | 'healing' | 'activity' | 'local';
@@ -17,9 +19,9 @@ const interestThemeOptions: { id: InterestTheme; icon: React.ReactNode; label: s
   { id: 'nature', icon: <TreeIcon className="w-full h-full" />, label: '자연' },
   { id: 'culture', icon: <BuildingIcon className="w-full h-full" />, label: '문화' },
   { id: 'food', icon: <UtensilsIcon className="w-full h-full" />, label: '맛집' },
-  { id: 'healing', icon: <ActivityIcon className="w-full h-full" />, label: '힐링' },
-  { id: 'activity', icon: <ActivityIcon className="w-full h-full" />, label: '문화' },
-  { id: 'local', icon: <BuildingIcon className="w-full h-full" />, label: '맛집' },
+  { id: 'healing', icon: <HealingIcon className="w-full h-full" />, label: '힐링' },
+  { id: 'activity', icon: <ActivityIcon className="w-full h-full" />, label: '액티비티' },
+  { id: 'local', icon: <LocalIcon className="w-full h-full" />, label: '로컬' },
 ];
 
 const InterestThemeSection = ({ selectedThemes, onToggleTheme, className }: InterestThemeSectionProps) => {

--- a/src/feature/mypage/components/SettingsSection.tsx
+++ b/src/feature/mypage/components/SettingsSection.tsx
@@ -93,14 +93,14 @@ const SettingsSection = ({
           onBioClear={() => setBio('')}
         />
 
-        {/* Travel Style Section */}
-        <div className="mt-10">
-          <TravelStyleSection selectedStyles={travelStyles} onToggleStyle={handleToggleTravelStyle} />
-        </div>
-
         {/* Interest Theme Section */}
         <div className="mt-10">
           <InterestThemeSection selectedThemes={interestThemes} onToggleTheme={handleToggleInterestTheme} />
+        </div>
+
+        {/* Travel Style Section */}
+        <div className="mt-10">
+          <TravelStyleSection selectedStyles={travelStyles} onToggleStyle={handleToggleTravelStyle} />
         </div>
 
         {/* Save Button */}

--- a/src/feature/mypage/components/StatusCard.tsx
+++ b/src/feature/mypage/components/StatusCard.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import ChevronRightIcon from '@/shared/assets/icon-chevron-right.svg?react';
 import React from 'react';
 
 interface StatusCardProps {
@@ -25,8 +24,8 @@ const StatusCard = ({ icon, label, count, onClick, className }: StatusCardProps)
       <div className="flex flex-col items-end">
         <span className="h1 text-base-color-0">{count}</span>
         <div className="flex items-center text-base-color-1 b2 mt-3">
-          <span>보러가기</span>
-          <ChevronRightIcon />
+          {/* <span>보러가기</span>
+          <ChevronRightIcon /> */}
         </div>
       </div>
     </div>

--- a/src/feature/mypage/components/TravelStyleSection.tsx
+++ b/src/feature/mypage/components/TravelStyleSection.tsx
@@ -1,8 +1,10 @@
 import clsx from 'clsx';
-import TreeIcon from '@/shared/assets/icon-tree.svg?react';
-import BuildingIcon from '@/shared/assets/icon-building.svg?react';
-import UtensilsIcon from '@/shared/assets/icon-utensils.svg?react';
-import ActivityIcon from '@/shared/assets/icon-activity.svg?react';
+import Free from '@assets/preference/icon-preference-style-free.svg?react';
+import Plan from '@assets/preference/icon-preference-style-plan.svg?react';
+import Schedule from '@assets/preference/icon-preference-style-schedule.svg?react';
+import Efficiency from '@assets/preference/icon-preference-style-efficiency.svg?react';
+import Improvise from '@assets/preference/icon-preference-style-imporvise.svg?react';
+import Stay from '@assets/preference/icon-preference-style-stay.svg?react';
 import StyleCard from './StyleCard';
 
 export type TravelStyle = 'free' | 'healing' | 'food' | 'activity' | 'accommodation' | 'other';
@@ -14,12 +16,12 @@ interface TravelStyleSectionProps {
 }
 
 const travelStyleOptions: { id: TravelStyle; icon: React.ReactNode; label: string }[] = [
-  { id: 'free', icon: <TreeIcon className="w-full h-full" />, label: '자유 여행' },
-  { id: 'healing', icon: <BuildingIcon className="w-full h-full" />, label: '힐링 · 여유 중심' },
-  { id: 'food', icon: <UtensilsIcon className="w-full h-full" />, label: '맛집 · 로컬 중심' },
-  { id: 'other', icon: <UtensilsIcon className="w-full h-full" />, label: '기타' },
-  { id: 'activity', icon: <ActivityIcon className="w-full h-full" />, label: '액티비티 중심' },
-  { id: 'accommodation', icon: <BuildingIcon className="w-full h-full" />, label: '숙소 중심' },
+  { id: 'free', icon: <Free className="w-full h-full" />, label: '자유 계획형' },
+  { id: 'healing', icon: <Plan className="w-full h-full" />, label: '계획 충실형' },
+  { id: 'food', icon: <Schedule className="w-full h-full" />, label: '느긋한 일정형' },
+  { id: 'other', icon: <Efficiency className="w-full h-full" />, label: '효율 중시형' },
+  { id: 'activity', icon: <Improvise className="w-full h-full" />, label: '즉흥 탐색형' },
+  { id: 'accommodation', icon: <Stay className="w-full h-full" />, label: '숙소 중심형' },
 ];
 
 const TravelStyleSection = ({ selectedStyles, onToggleStyle, className }: TravelStyleSectionProps) => {

--- a/src/feature/mypage/setting/components/DataPrivacySection.tsx
+++ b/src/feature/mypage/setting/components/DataPrivacySection.tsx
@@ -1,27 +1,38 @@
+import TermsModal from '@/feature/signup/components/TermsModal';
 import ArrowRightIcon from '@assets/icon-arrow-right.svg?react';
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
 
 const PRIVACY_LINKS = [
-  { id: 'privacy-policy', label: '개인정보 처리방침', to: '#' },
-  { id: 'terms', label: '이용약관', to: '#' },
+  { id: 'privacy-policy', label: '개인정보 처리방침', key: 'privacy' },
+  { id: 'terms', label: '이용약관', key: 'service' },
 ];
 
 const DataPrivacySection = () => {
+  const [modalType, setModalType] = useState<(typeof PRIVACY_LINKS)[number]['key'] | null>(null);
+
   return (
     <div className="flex flex-col gap-5">
       <h3 className="h4 font-medium text-base-color-0">개인정보 처리방침 및 이용약관</h3>
 
       <div className="flex gap-9">
         {PRIVACY_LINKS.map((link) => (
-          <Link
+          <button
             key={link.id}
-            to={link.to}
+            onClick={() => setModalType(link.key)}
             className="flex items-center justify-between flex-1 px-3 py-5 bg-base-color-5 rounded-[10px] transition-colors cursor-pointer">
             <span className="b4 text-base-color-0">{link.label}</span>
             <ArrowRightIcon fill="#4A5569" />
-          </Link>
+          </button>
         ))}
       </div>
+
+      {modalType && (
+        <TermsModal
+          type={modalType as 'service' | 'privacy' | 'marketing'}
+          onClose={() => setModalType(null)}
+          hasCheckbox={false}
+        />
+      )}
     </div>
   );
 };

--- a/src/feature/signup/components/TermsModal.tsx
+++ b/src/feature/signup/components/TermsModal.tsx
@@ -11,11 +11,12 @@ import MainBg from '@/shared/components/MainBg';
 interface TemrsModalProps {
   type: 'service' | 'privacy' | 'marketing';
   onClose: () => void;
-  onChange: (checked: boolean) => void;
-  agreements: boolean;
+  onChange?: (checked: boolean) => void;
+  agreements?: boolean;
+  hasCheckbox?: boolean;
 }
 
-const TermsModal = ({ type, onClose, onChange, agreements }: TemrsModalProps) => {
+const TermsModal = ({ type, onClose, onChange, agreements = false, hasCheckbox = true }: TemrsModalProps) => {
   const term = TERMS[type]; // 어떤 모달인지
   const checkRef = useRef<HTMLDivElement>(null);
 
@@ -27,7 +28,7 @@ const TermsModal = ({ type, onClose, onChange, agreements }: TemrsModalProps) =>
     const isBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 5;
 
     if (isBottom && !agreements) {
-      onChange(true);
+      onChange?.(true);
     }
   };
 
@@ -97,33 +98,35 @@ const TermsModal = ({ type, onClose, onChange, agreements }: TemrsModalProps) =>
           ))}
         </section>
 
-        <div className="h-[195px] bg-base-color-5 py-[35px] px-[26px] flex flex-col gap-[20px] rounded-[15px]">
-          <Checkbox
-            text="내용을 모두 확인하였으며 동의합니다."
-            outline={true}
-            checked={agreements}
-            onChange={onChange}
-            className="w-full max-w-none"
-          />
-          <DualButton
-            left={{
-              text: '취소',
-              variant: 'white',
-              className: 'border-[rgba(0,0,0,0.1)]',
-              onClick: onClose,
-            }}
-            right={{
-              text: '확인',
-              disabled: !agreements,
-              onClick: onClose,
-            }}
-            width={105}
-            height={45}
-            gap={17}
-            textSize={18}
-            className="flex justify-end"
-          />
-        </div>
+        {hasCheckbox && (
+          <div className="h-[195px] bg-base-color-5 py-[35px] px-[26px] flex flex-col gap-[20px] rounded-[15px]">
+            <Checkbox
+              text="내용을 모두 확인하였으며 동의합니다."
+              outline={true}
+              checked={agreements}
+              onChange={onChange ?? (() => {})}
+              className="w-full max-w-none"
+            />
+            <DualButton
+              left={{
+                text: '취소',
+                variant: 'white',
+                className: 'border-[rgba(0,0,0,0.1)]',
+                onClick: onClose,
+              }}
+              right={{
+                text: '확인',
+                disabled: !agreements,
+                onClick: onClose,
+              }}
+              width={105}
+              height={45}
+              gap={17}
+              textSize={18}
+              className="flex justify-end"
+            />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #98

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

- 마이페이지 모달 연결
- 관심 테마, 여행 스타일 이미지 회원가입때와 같은 이미지로 통일

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
| 관심 테마, 여행 스타일 |
| --- |
| <img width="1331" height="829" alt="스크린샷 2026-02-12 오후 9 10 36" src="https://github.com/user-attachments/assets/ae29103f-0fbb-4b6a-90df-4fc28b7c6612" /> |

- 모달 연결

https://github.com/user-attachments/assets/20689340-b4c6-4011-a265-52f3a7a43a3c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Changes**
  * 관심사 테마 및 여행 스타일 아이콘이 새로운 디자인으로 업데이트되었습니다.
  * 설정 페이지의 섹션 순서가 변경되었습니다.
  * 상태 카드의 우측 아이콘이 제거되었습니다.
  * 약관 및 개인정보 페이지가 모달 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->