### PR TITLE
[Feat] 모바일 기기와 화면 너비 1024px 미만 환경에서 콘텐츠 차단 기능 추가

### DIFF
--- a/src/shared/layouts/DefaultLayout.tsx
+++ b/src/shared/layouts/DefaultLayout.tsx
@@ -33,7 +33,7 @@ const DefaultLayout = ({ showNavbar = true, protectedRoutes = false }: DefaultLa
       const isTouchPrimary = window.matchMedia('(pointer: coarse)').matches;
 
       // 2. 화면 너비 체크 (반응형 감지)
-      const isSmallScreen = window.innerWidth < 1024;
+      const isSmallScreen = window.innerWidth < 1920;
 
       if (isTouchPrimary || isSmallScreen) {
         setIsBlocked(true);

--- a/src/shared/layouts/DefaultLayout.tsx
+++ b/src/shared/layouts/DefaultLayout.tsx
@@ -1,13 +1,15 @@
 import Navbar from '@/shared/components/Navbar/Navbar';
 import MainBg from '@components/MainBg';
 import SplashFlow from '@/feature/splash/SplashFlow';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
+import { useState } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import ScrollToTop from '../components/scrollToTop';
 import Footer from '../components/Footer/Footer';
 import { useRouteGuard } from '@/feature/splash/hooks/useRouteGuard';
 import { useSplashStore } from '../stores/splashStore';
 import { useShallow } from 'zustand/react/shallow';
+import Logo from '@assets/logo/logo-auth.svg?react';
 
 interface DefaultLayoutProps {
   showNavbar?: boolean;
@@ -23,6 +25,29 @@ const DefaultLayout = ({ showNavbar = true, protectedRoutes = false }: DefaultLa
     })),
   );
 
+  const [isBlocked, setIsBlocked] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      // 1. 주 입력 장치가 '터치'인 기기 감지 (모바일, 태블릿)
+      const isTouchPrimary = window.matchMedia('(pointer: coarse)').matches;
+
+      // 2. 화면 너비 체크 (반응형 감지)
+      const isSmallScreen = window.innerWidth < 1024;
+
+      if (isTouchPrimary || isSmallScreen) {
+        setIsBlocked(true);
+        console.log('📱 [Travlocks] 모바일/태블릿 접속 제한 활성화');
+      } else {
+        setIsBlocked(false);
+      }
+    };
+
+    checkMobile();
+    window.addEventListener('resize', checkMobile); // 창 크기 변경 시 다시 계산
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
   if (redirectTo) {
     return <Navigate to={redirectTo} state={{ from: returnTo }} replace />;
   }
@@ -30,6 +55,23 @@ const DefaultLayout = ({ showNavbar = true, protectedRoutes = false }: DefaultLa
   return (
     <div className="relative w-full min-h-dvh overflow-hidden" aria-label="메인 레이아웃">
       <ScrollToTop />
+
+      {/* 모바일/태블릿 접속 제한 오버레이 */}
+      {isBlocked && (
+        <div className="fixed inset-0 z-[10000] bg-base-color-6 flex flex-col items-center justify-center px-6 text-center">
+          <div className="flex flex-col gap-6 items-center">
+            <Logo className="w-60 h-40" />
+            <div className="flex flex-col gap-2">
+              <p className="h5 text-base-color-0 font-semibold">웹에서 봐주세요!</p>
+              <p className="b6 text-base-color-2">
+                트래블록스는 최적인 경험을 위해
+                <br />
+                PC 웹 환경(너비 1024px 이상)에 최적화되어 있습니다.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* 메인 배경 */}
       {shouldShowSplashOverlay || isAuthPage ? <MainBg /> : <div className="absolute inset-0 z-base bg-base-color-6" />}

--- a/src/shared/layouts/DefaultLayout.tsx
+++ b/src/shared/layouts/DefaultLayout.tsx
@@ -33,7 +33,7 @@ const DefaultLayout = ({ showNavbar = true, protectedRoutes = false }: DefaultLa
       const isTouchPrimary = window.matchMedia('(pointer: coarse)').matches;
 
       // 2. 화면 너비 체크 (반응형 감지)
-      const isSmallScreen = window.innerWidth < 1920;
+      const isSmallScreen = window.innerWidth < 1024;
 
       if (isTouchPrimary || isSmallScreen) {
         setIsBlocked(true);

--- a/src/shared/layouts/DefaultLayout.tsx
+++ b/src/shared/layouts/DefaultLayout.tsx
@@ -25,7 +25,11 @@ const DefaultLayout = ({ showNavbar = true, protectedRoutes = false }: DefaultLa
     })),
   );
 
-  const [isBlocked, setIsBlocked] = useState(false);
+  const [isBlocked, setIsBlocked] = useState(() => {
+    const isTouchPrimary = window.matchMedia('(pointer: coarse)').matches;
+    const isSmallScreen = window.innerWidth < 1024;
+    return isTouchPrimary || isSmallScreen;
+  });
 
   useEffect(() => {
     const checkMobile = () => {
@@ -34,17 +38,10 @@ const DefaultLayout = ({ showNavbar = true, protectedRoutes = false }: DefaultLa
 
       // 2. 화면 너비 체크 (반응형 감지)
       const isSmallScreen = window.innerWidth < 1024;
-
-      if (isTouchPrimary || isSmallScreen) {
-        setIsBlocked(true);
-        console.log('📱 [Travlocks] 모바일/태블릿 접속 제한 활성화');
-      } else {
-        setIsBlocked(false);
-      }
+      setIsBlocked(isTouchPrimary || isSmallScreen);
     };
 
-    checkMobile();
-    window.addEventListener('resize', checkMobile); // 창 크기 변경 시 다시 계산
+    window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
 


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #122

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
터치 가능한 기기 + 너비 1024px 이하 기기에서는 컨텐츠 열람 제한 뷰가 보이도록 합니다.

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

https://github.com/user-attachments/assets/dfff818c-4da9-40e9-afa8-44d11afa1539



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 터치 기기 및 화면 너비가 작은 환경에서 데스크톱 전용 접근을 안내하는 전면 오버레이가 추가되었습니다.
  * 오버레이는 로고와 안내 메시지를 포함하며 주요 콘텐츠 위에 고정되어 표시됩니다.
  * 초기 기기 감지와 창 크기 변경을 통해 접근 상태를 동적으로 갱신하여 사용자 상호작용을 제한하고 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->