### PR TITLE
[Fix] 폴백 로직이 올바르지 않게 동작하고 있던 문제 수정

### DIFF
--- a/src/feature/block/blockBuild/blockBuild.type.ts
+++ b/src/feature/block/blockBuild/blockBuild.type.ts
@@ -138,6 +138,10 @@ export type CanvasVlockData = {
   templateVlockId: number;
   orderNo: number;
   stayHours: number;
+  canvasX: number | null;
+  canvasY: number | null;
+  inputPort: ConnectionPortType | null;
+  outputPort: ConnectionPortType | null;
   nextMoveMinutes: number;
   vlock: CanvasVlockBrief;
 };

--- a/src/feature/block/blockBuild/hooks/useBlockDrag.ts
+++ b/src/feature/block/blockBuild/hooks/useBlockDrag.ts
@@ -47,6 +47,7 @@ export const useBlockDrag = ({
   // 항상 최신 상태를 참조하기 위한 ref
   const puzzleBlocksRef = useRef(puzzleBlocks);
   const zoomRef = useRef(zoom);
+  const isDraggingRef = useRef(false);
 
   useEffect(() => {
     puzzleBlocksRef.current = puzzleBlocks;
@@ -56,10 +57,37 @@ export const useBlockDrag = ({
     zoomRef.current = zoom;
   }, [zoom]);
 
+  const clearTransientDragState = useCallback(() => {
+    if (!isDraggingRef.current) return;
+
+    isDraggingRef.current = false;
+    onDragStateChange?.(false);
+    setActiveDrag(null);
+    setDockHint(null);
+  }, [onDragStateChange]);
+
+  useEffect(() => {
+    const handlePointerRelease = () => {
+      // dnd-kit onDragEnd가 누락되는 경우를 대비한 안전장치
+      clearTransientDragState();
+    };
+
+    window.addEventListener('pointerup', handlePointerRelease);
+    window.addEventListener('pointercancel', handlePointerRelease);
+
+    return () => {
+      window.removeEventListener('pointerup', handlePointerRelease);
+      window.removeEventListener('pointercancel', handlePointerRelease);
+    };
+  }, [clearTransientDragState]);
+
   const onDragStart = useCallback(
     (e: DragStartEvent) => {
       const type = e.active.data.current?.type as DragType | undefined;
-      if (type) onDragStateChange?.(true);
+      if (type) {
+        isDraggingRef.current = true;
+        onDragStateChange?.(true);
+      }
 
       if (type === 'blockSidebar') {
         const item = e.active.data.current?.item as SidebarBlock | undefined;
@@ -105,6 +133,8 @@ export const useBlockDrag = ({
 
   const onDragMove = useCallback(
     (e: DragMoveEvent) => {
+      if (!isDraggingRef.current) return;
+
       const boardEl = boardRef.current;
       if (!boardEl) return;
 
@@ -136,6 +166,7 @@ export const useBlockDrag = ({
 
   const onDragEnd = useCallback(
     (e: DragEndEvent) => {
+      isDraggingRef.current = false;
       onDragStateChange?.(false);
       setActiveDrag(null);
       setDockHint(null);
@@ -253,10 +284,8 @@ export const useBlockDrag = ({
   );
 
   const onDragCancel = useCallback(() => {
-    onDragStateChange?.(false);
-    setActiveDrag(null);
-    setDockHint(null);
-  }, [onDragStateChange]);
+    clearTransientDragState();
+  }, [clearTransientDragState]);
 
   return {
     sensors,

--- a/src/feature/block/blockBuild/utils/canvasFallbackMapper.ts
+++ b/src/feature/block/blockBuild/utils/canvasFallbackMapper.ts
@@ -1,12 +1,17 @@
 import { categoryColor } from '../components/side/block-styles';
-import type { CanvasData } from '../blockBuild.type';
+import type { CanvasData, CanvasVlockData } from '../blockBuild.type';
 import type { Block, CategoryType } from '../types/block';
 import { createStartBlockShape, getBlockShapeByDuration } from './blockShapeByDuration';
+import { getAllSnapPositionsToTail } from './snapToTail';
 
 const START_BLOCK_ID = 0;
 const START_POS = { x: 44, y: 76 };
-const BOARD_PADDING = { left: 80, top: 220 };
-const BOARD_RANGE = { width: 1400, height: 2000 };
+const CONNECTED_ORDER_GAP = 20;
+const FALLBACK_GRID_COLUMNS = 6;
+const FALLBACK_GRID_ROWS = 4;
+const FALLBACK_GRID_CELL = { x: 150, y: 120 };
+const FALLBACK_GRID_OFFSET_FROM_START = { x: 160, y: 120 };
+const DAY_SEED_MULTIPLIER = 1000;
 
 const KNOWN_CATEGORIES: CategoryType[] = ['숙소', '식당', '카페', '쇼핑', '관광지', '문화', '액티비티', '투어', '기타'];
 
@@ -25,19 +30,132 @@ const toDurationLabel = (category: CategoryType, stayHours: number): string => {
   return `${Math.max(1, Math.round(hours))}시간`;
 };
 
-const seededUnit = (seed: number): number => {
-  const x = Math.sin(seed * 12.9898) * 43758.5453;
-  return x - Math.floor(x);
-};
-
 const seededPosition = (seed: number) => {
-  const xSeed = seededUnit(seed + 17);
-  const ySeed = seededUnit(seed + 71);
+  const normalizedSeed = Math.abs(Math.trunc(seed));
+  const slotCount = FALLBACK_GRID_COLUMNS * FALLBACK_GRID_ROWS;
+  const slot = normalizedSeed % slotCount;
+  const col = slot % FALLBACK_GRID_COLUMNS;
+  const row = Math.floor(slot / FALLBACK_GRID_COLUMNS);
 
   return {
-    x: Math.round(BOARD_PADDING.left + xSeed * BOARD_RANGE.width),
-    y: Math.round(BOARD_PADDING.top + ySeed * BOARD_RANGE.height),
+    x: START_POS.x + FALLBACK_GRID_OFFSET_FROM_START.x + col * FALLBACK_GRID_CELL.x,
+    y: START_POS.y + FALLBACK_GRID_OFFSET_FROM_START.y + row * FALLBACK_GRID_CELL.y,
   };
+};
+
+const sortConnectedByOrder = (a: CanvasVlockData, b: CanvasVlockData): number => {
+  return a.orderNo - b.orderNo || a.templateVlockId - b.templateVlockId;
+};
+
+const splitVlocks = (vlocks: CanvasVlockData[]): { connected: CanvasVlockData[]; detached: CanvasVlockData[] } => {
+  const connected = vlocks.filter((v) => v.orderNo > 0).sort(sortConnectedByOrder);
+  const detached = vlocks.filter((v) => v.orderNo <= 0);
+  return { connected, detached };
+};
+
+const hasServerPosition = (
+  vlock: CanvasVlockData,
+): vlock is CanvasVlockData & {
+  canvasX: number;
+  canvasY: number;
+} => {
+  return (
+    typeof vlock.canvasX === 'number' &&
+    Number.isFinite(vlock.canvasX) &&
+    typeof vlock.canvasY === 'number' &&
+    Number.isFinite(vlock.canvasY)
+  );
+};
+
+const resolveInitialPosition = (vlock: CanvasVlockData, dayNo: number): { x: number; y: number } => {
+  if (hasServerPosition(vlock)) {
+    return { x: vlock.canvasX, y: vlock.canvasY };
+  }
+  // 좌표가 null 일 때 매번 옮겨다니지 않도록 시드를 고정
+  return seededPosition(vlock.templateVlockId + dayNo * DAY_SEED_MULTIPLIER);
+};
+
+const buildConnectedOrderPosition = (tail: Block, block: Block): { x: number; y: number } => {
+  const options = getAllSnapPositionsToTail({
+    tail,
+    drag: { points: block.points, connectors: block.connectors },
+  });
+  if (options.length > 0) {
+    return options[0];
+  }
+  return { x: tail.x + tail.w + CONNECTED_ORDER_GAP, y: tail.y };
+};
+
+const createMappedBlock = (vlock: CanvasVlockData, dayNo: number): Block => {
+  const category = toKnownCategory(vlock.vlock.category);
+  const duration = toDurationLabel(category, vlock.stayHours);
+  const shape = getBlockShapeByDuration(duration, category);
+  const initial = resolveInitialPosition(vlock, dayNo);
+
+  return {
+    blockId: vlock.vlock.vlockId,
+    templateVlocksId: vlock.templateVlockId,
+    name: vlock.vlock.name,
+    category,
+    duration,
+    imageUrl: undefined,
+    color: categoryColor[category],
+    x: initial.x,
+    y: initial.y,
+    w: shape.w,
+    h: shape.h,
+    points: shape.points,
+    connectors: shape.connectors,
+    connectedTo: null,
+    connectedFrom: null,
+  };
+};
+
+const indexBlocksByTemplateVlockId = (blocks: Block[]): Map<number, Block> => {
+  const entries: Array<[number, Block]> = [];
+  for (const block of blocks) {
+    if (typeof block.templateVlocksId === 'number') {
+      entries.push([block.templateVlocksId, block]);
+    }
+  }
+  return new Map(entries);
+};
+
+const rebuildConnectedPositionsByOrder = (
+  connected: CanvasVlockData[],
+  blocksByTemplateVlockId: Map<number, Block>,
+  start: Block,
+) => {
+  let tail: Block = start;
+  for (const item of connected) {
+    const block = blocksByTemplateVlockId.get(item.templateVlockId);
+    if (!block) continue;
+
+    const { x: newX, y: newY } = buildConnectedOrderPosition(tail, block);
+    block.x = newX;
+    block.y = newY;
+    tail = block;
+  }
+};
+
+const linkConnectedChain = (
+  connected: CanvasVlockData[],
+  blocksByTemplateVlockId: Map<number, Block>,
+  start: Block,
+) => {
+  for (let i = 0; i < connected.length; i++) {
+    const current = blocksByTemplateVlockId.get(connected[i].templateVlockId);
+    if (!current) continue;
+
+    const prev = i > 0 ? blocksByTemplateVlockId.get(connected[i - 1].templateVlockId) : start;
+    const next = i < connected.length - 1 ? blocksByTemplateVlockId.get(connected[i + 1].templateVlockId) : null;
+
+    current.connectedFrom = prev?.blockId ?? null;
+    current.connectedTo = next?.blockId ?? null;
+  }
+
+  start.connectedTo =
+    connected.length > 0 ? (blocksByTemplateVlockId.get(connected[0].templateVlockId)?.blockId ?? null) : null;
 };
 
 const createStartBlock = (): Block => {
@@ -59,63 +177,26 @@ const createStartBlock = (): Block => {
 };
 
 /**
- * Temporary fallback mapper.
- * The canvas endpoint currently lacks layout + port fields, so this mapper restores
- * chain structure from orderNo and places blocks in deterministic pseudo-random positions.
+ * 서버에서 가져온 일부 필드가 null일 때 클라이언트에서 처리 로직
+ * - 시작 블록에 붙은 블록이 canvasX/Y를 가지고 있으면 그대로 사용
+ * - canvasX/Y가 모종의 이유로 null이 되면 orderNo를 사용해 원복 (inputPort, outputPort는 랜덤)
+ * - 연결되지 않은 블록이 canvasX/Y가 null이면 랜덤으로 좌표 생성
  */
 export const mapCanvasToBlocksFallback = (canvas: CanvasData): Block[] => {
   const start = createStartBlock();
   if (!canvas.vlocks.length) return [start];
 
-  const connected = canvas.vlocks
-    .filter((v) => v.orderNo > 0)
-    .sort((a, b) => a.orderNo - b.orderNo || a.templateVlockId - b.templateVlockId);
-
-  const detached = canvas.vlocks.filter((v) => v.orderNo <= 0).sort((a, b) => a.templateVlockId - b.templateVlockId);
-
+  const { connected, detached } = splitVlocks(canvas.vlocks);
   const ordered = [...connected, ...detached];
+  const mapped = ordered.map((vlock) => createMappedBlock(vlock, canvas.dayNo));
+  const mappedByTemplateVlockId = indexBlocksByTemplateVlockId(mapped);
 
-  const mapped: Block[] = ordered.map((vlock): Block => {
-    const category = toKnownCategory(vlock.vlock.category);
-    const duration = toDurationLabel(category, vlock.stayHours);
-    const shape = getBlockShapeByDuration(duration, category);
-    const pos = seededPosition(vlock.templateVlockId + canvas.dayNo * 1000);
-
-    return {
-      blockId: vlock.vlock.vlockId,
-      templateVlocksId: vlock.templateVlockId,
-      name: vlock.vlock.name,
-      category,
-      duration,
-      imageUrl: undefined,
-      color: categoryColor[category],
-      x: pos.x,
-      y: pos.y,
-      w: shape.w,
-      h: shape.h,
-      points: shape.points,
-      connectors: shape.connectors,
-      connectedTo: null,
-      connectedFrom: null,
-    };
-  });
-
-  for (let i = 0; i < connected.length; i++) {
-    const current = mapped.find((b) => b.templateVlocksId === connected[i].templateVlockId);
-    if (!current) continue;
-
-    const prev = i > 0 ? mapped.find((b) => b.templateVlocksId === connected[i - 1].templateVlockId) : start;
-    const next =
-      i < connected.length - 1 ? mapped.find((b) => b.templateVlocksId === connected[i + 1].templateVlockId) : null;
-
-    current.connectedFrom = prev?.blockId ?? null;
-    current.connectedTo = next?.blockId ?? null;
+  const shouldRebuildConnectedByOrder = connected.some((v) => !hasServerPosition(v));
+  if (shouldRebuildConnectedByOrder) {
+    rebuildConnectedPositionsByOrder(connected, mappedByTemplateVlockId, start);
   }
 
-  start.connectedTo =
-    connected.length > 0
-      ? (mapped.find((b) => b.templateVlocksId === connected[0].templateVlockId)?.blockId ?? null)
-      : null;
+  linkConnectedChain(connected, mappedByTemplateVlockId, start);
 
   return [start, ...mapped];
 };

--- a/src/shared/hooks/useCanvasPanZoom.ts
+++ b/src/shared/hooks/useCanvasPanZoom.ts
@@ -196,10 +196,17 @@ export function useCanvasPanZoom(options: Options = { zoom: 1, onZoomChange: () 
 
   // 패닝 이벤트 해제 핸들러
   const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!panRef.current.active) return;
+
     e.preventDefault();
     e.stopPropagation();
+
     const el = viewportRef.current;
-    if (!el || !panRef.current.active) return;
+    if (!el) {
+      panRef.current.active = false;
+      setIsPanning(false);
+      return;
+    }
 
     try {
       el.releasePointerCapture?.(panRef.current.pointerId);


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #128 

### ✨️ 작업 내용

- 블록 캔버스 hydration 할 때 폴백 좌표가 올바르지 않게 들어가고 있던 문제 수정 (rebase 할 때 잘못 들어간 것으로 추정)
- 추가로 블록 움직일 때 간헐적으로 dockHint가 그대로 남아있던 문제도 수정했습니다

### 💭 코멘트

- day 1 -> day 2 -> day 1를 매우 빠른 속도로 (i.e. debounce 500ms 이내) 변경하면 race condition으로 마지막 블록 위치 업로드가 취소되는 이슈가 남아있습니다.
  - hydration이 day 별로 진행되는데, day1이 pending인 상태에서 day2에 갔다가 재빠르게 day1로 돌아오면 day1이 hydration을 시도하게 되면서 pending인 day1의 업로드가 취소됨
  - 다만 매우 빠른 속도로 움직여야 하기 때문에 큰 이슈가 되지 않을 것 같아서 우선 노운으로 남겨두고 급한 불부터 끄고자 합니다

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
