### PR TITLE
[Fix] 템플릿 탐색 api 수정

### DIFF
--- a/src/feature/main_page/SideBar.tsx
+++ b/src/feature/main_page/SideBar.tsx
@@ -15,6 +15,7 @@ import { useToggleFavorite } from './hooks/mutations/useToggleFavorite';
 import { toast } from '@/shared/stores/toastStore';
 import type { ResponseRemixDto } from '@/feature/home/types/template';
 import { motion, AnimatePresence } from 'motion/react';
+import { formatOneDecimal } from '@/shared/utils/format';
 
 interface SideBarContentProps {
   templateId: number;
@@ -111,7 +112,11 @@ const SideBarContent = ({ templateId, onClose, isClosing }: SideBarContentProps)
         {/* 프로필 카드 */}
         <div className="flex items-center gap-6.75 p-4.5 border border-base-color rounded-[5px] bg-base-color-5">
           <div className="w-12 h-12 rounded-full overflow-hidden shrink-0">
-            <img src={ProfileImageUrl} alt="profile" className="w-full h-full object-cover" />
+            <img
+              src={detail?.ownerProfileImage || ProfileImageUrl}
+              alt="profile"
+              className="w-full h-full object-cover"
+            />
           </div>
           <span className="h9 text-base-color-0">@{detail?.ownerNickname}</span>
         </div>
@@ -138,7 +143,7 @@ const SideBarContent = ({ templateId, onClose, isClosing }: SideBarContentProps)
               <StarIcon className="w-6 h-6" />
             </div>
             <div className="flex flex-col items-center">
-              <span className="h9 text-base-color-0">{detail?.rating}</span>
+              <span className="h9 text-base-color-0">{formatOneDecimal(detail?.rating)}</span>
               <span className="b6 text-base-color-2">평점</span>
             </div>
           </div>

--- a/src/feature/search/TemplateContent.tsx
+++ b/src/feature/search/TemplateContent.tsx
@@ -29,7 +29,7 @@ const initialFilters: FilterState = {
   transportTypes: [],
 };
 
-const initialSort: SortOption = 'rating';
+const initialSort: SortOption = '별점순';
 
 interface TemplateContentProps {
   onCardClick?: (templateId: number) => void;
@@ -169,9 +169,6 @@ const TemplateContent = ({ onCardClick }: TemplateContentProps) => {
               />
             </section>
           </main>
-
-          {/* 오른쪽 사이드 패널 (나중에 사용) */}
-          <aside className="w-[300px] flex-shrink-0">{/* 추후 컨텐츠 추가 예정 */}</aside>
         </div>
       </div>
     </div>

--- a/src/feature/search/api/search.api.ts
+++ b/src/feature/search/api/search.api.ts
@@ -33,7 +33,16 @@ export async function getTemplates(params: SearchTemplateParams): Promise<Search
         isSuccess: true,
         successCode: 'TEMPLATE_EXPLORE_EMPTY',
         successMessage: '조건에 맞는 템플릿이 없습니다.',
-        data: [],
+        data: {
+          content: [],
+          page: 0,
+          size: 0,
+          totalElements: 0,
+          totalPages: 0,
+          first: true,
+          last: true,
+          empty: true,
+        },
       };
     }
     throw error;

--- a/src/feature/search/component/ResultSection/PageNavigation.tsx
+++ b/src/feature/search/component/ResultSection/PageNavigation.tsx
@@ -9,6 +9,9 @@ interface PageNavigationProps {
   /** 현재 페이지 번호 (1부터 시작) */
   currentPage: number;
 
+  /** 전체 페이지 수 */
+  totalPages: number;
+
   /** 페이지 변경 시 호출되는 콜백 함수 */
   onPageChange: (page: number) => void;
 }
@@ -18,20 +21,24 @@ interface PageNavigationProps {
  *
  * @remarks
  * - 5개 단위로 페이지 번호를 표시합니다 (1~5, 6~10, ...).
- * - 전체 페이지 수를 모르므로 다음 버튼은 항상 활성화됩니다.
- * - 결과가 없는 페이지에 도달하면 상위 컴포넌트에서 빈 결과 화면을 보여줍니다.
+ * - 전체 페이지 수에 따라 다음 버튼 활성화 여부를 결정합니다.
  *
  * @param props.currentPage - 현재 페이지 번호 (1부터 시작)
+ * @param props.totalPages - 전체 페이지 수
  * @param props.onPageChange - 페이지 변경 시 호출되는 콜백
  */
-const PageNavigation = ({ currentPage, onPageChange }: PageNavigationProps) => {
+const PageNavigation = ({ currentPage, totalPages, onPageChange }: PageNavigationProps) => {
   const maxVisiblePages = 5;
   const currentBlock = Math.ceil(currentPage / maxVisiblePages);
   const startPage = (currentBlock - 1) * maxVisiblePages + 1;
 
-  const pages = Array.from({ length: maxVisiblePages }, (_, i) => startPage + i);
+  // 실제 마지막 페이지까지만 표시
+  const endPage = Math.min(startPage + maxVisiblePages - 1, totalPages);
+
+  const pages = Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
 
   const isFirstPage = currentPage === 1;
+  const isLastPage = currentPage === totalPages;
 
   const handlePrevious = () => {
     if (!isFirstPage) {
@@ -40,8 +47,12 @@ const PageNavigation = ({ currentPage, onPageChange }: PageNavigationProps) => {
   };
 
   const handleNext = () => {
-    onPageChange(currentPage + 1);
+    if (!isLastPage) {
+      onPageChange(currentPage + 1);
+    }
   };
+
+  if (totalPages === 0) return null;
 
   return (
     <nav className={PageNavigationStyle.container}>
@@ -72,7 +83,8 @@ const PageNavigation = ({ currentPage, onPageChange }: PageNavigationProps) => {
       <button
         type="button"
         onClick={handleNext}
-        className={PageNavigationStyle.arrowButton(false)}
+        disabled={isLastPage}
+        className={PageNavigationStyle.arrowButton(isLastPage)}
         aria-label="다음 페이지">
         <ArrowRightIcon className="w-5 h-5" />
       </button>

--- a/src/feature/search/component/ResultSection/SearchResultCards.tsx
+++ b/src/feature/search/component/ResultSection/SearchResultCards.tsx
@@ -74,8 +74,8 @@ const SearchResultCards = ({
   }
 
   // 결과 없음
-  // SuccessPayload 사용 시 data.data가 템플릿 배열입니다.
-  if (!data?.data || data.data.length === 0) {
+  // SuccessPayload 사용 시 data.data가 PageResponse<Template>입니다.
+  if (!data?.data?.content || data.data.content.length === 0) {
     return (
       <EmptyResultCard
         title="해당 조건에 맞는 템플릿이 없어요."
@@ -89,13 +89,16 @@ const SearchResultCards = ({
     <div className="flex flex-col gap-[80px]">
       {/* 템플릿 카드 그리드 (3x3) */}
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-[20px]">
-        {data.data.map((template) => (
-          <TemplateCard key={template.templateId} template={template} onCardClick={onCardClick} />
-        ))}
+        {(() => {
+          console.log(data.data.content.map((t) => ({ templateId: t.templateId, page: data.data.page })));
+          return data.data.content.map((template) => (
+            <TemplateCard key={template.templateId} template={template} onCardClick={onCardClick} />
+          ));
+        })()}
       </div>
 
       {/* 페이지네이션 */}
-      <PageNavigation currentPage={currentPage} onPageChange={onPageChange} />
+      <PageNavigation currentPage={currentPage} totalPages={data.data.totalPages} onPageChange={onPageChange} />
     </div>
   );
 };

--- a/src/feature/search/component/SortDropDown.tsx
+++ b/src/feature/search/component/SortDropDown.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { type SortOption, SORT_OPTIONS } from '@/feature/search/types/searchTemplate.types';
+import { type SortOption, SORT_OPTIONS_LIST } from '@/feature/search/types/searchTemplate.types';
 import { DropdownStyle } from '@/feature/search/style/Dropdown.style';
 import ArrowDownIcon from '@/shared/assets/icon-arrow-down.svg?react';
 
@@ -52,7 +52,7 @@ const SortDropDown = ({ value, onChange }: SortDropDownProps) => {
   return (
     <div className={DropdownStyle.container} ref={dropdownRef}>
       <button type="button" className={DropdownStyle.button} onClick={() => setIsOpen(!isOpen)}>
-        <span>{SORT_OPTIONS[value]}</span>
+        <span>{value}</span>
         <div className={DropdownStyle.arrowIconWrapper}>
           <ArrowDownIcon className={DropdownStyle.arrowIcon(isOpen)} />
         </div>
@@ -60,13 +60,13 @@ const SortDropDown = ({ value, onChange }: SortDropDownProps) => {
 
       {isOpen && (
         <div className={DropdownStyle.menu}>
-          {Object.entries(SORT_OPTIONS).map(([key, label]) => (
+          {SORT_OPTIONS_LIST.map((option) => (
             <button
-              key={key}
+              key={option}
               type="button"
-              className={DropdownStyle.menuItem(value === key)}
-              onClick={() => handleSelect(key as SortOption)}>
-              {label}
+              className={DropdownStyle.menuItem(value === option)}
+              onClick={() => handleSelect(option)}>
+              {option}
             </button>
           ))}
         </div>

--- a/src/feature/search/hooks/useTemplateSearch.ts
+++ b/src/feature/search/hooks/useTemplateSearch.ts
@@ -16,7 +16,6 @@ function buildParams(keyword: string, filters: FilterState, sort: string, page: 
   const params: SearchTemplateParams = {
     sort,
     page: page - 1, // API는 0-based page index 사용
-    size: 9,
   };
 
   if (keyword.trim()) {
@@ -63,9 +62,8 @@ export function useTemplateSearch(keyword: string, filters: FilterState, sort: S
   return useQuery({
     queryKey: [QUERY_KEY.templateSearch, keyword, filters, sort, page],
     queryFn: () => getTemplates(params),
-    staleTime: 0, // 항상 최신 데이터 유지
-    gcTime: 0, // 캐시 즉시 만료 (데이터 꼬임 방지)
-    // 초기 로드 시에만 자동으로 가져오기
+    staleTime: 0,
+    gcTime: 0, // 캐시 즉시 만료
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/src/feature/search/hooks/useTemplateSearch.ts
+++ b/src/feature/search/hooks/useTemplateSearch.ts
@@ -63,8 +63,8 @@ export function useTemplateSearch(keyword: string, filters: FilterState, sort: S
   return useQuery({
     queryKey: [QUERY_KEY.templateSearch, keyword, filters, sort, page],
     queryFn: () => getTemplates(params),
-    staleTime: 5 * 60 * 1000, // 5분
-    gcTime: 10 * 60 * 1000, // 10분
+    staleTime: 0, // 항상 최신 데이터 유지
+    gcTime: 0, // 캐시 즉시 만료 (데이터 꼬임 방지)
     // 초기 로드 시에만 자동으로 가져오기
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/src/feature/search/types/searchTemplate.types.ts
+++ b/src/feature/search/types/searchTemplate.types.ts
@@ -5,11 +5,11 @@ import type { SuccessPayload } from '@/shared/types/common';
  * 템플릿 정렬 옵션 타입
  *
  * @remarks
- * - 'rating': 별점 높은 순
- * - 'popular': 인기 많은 순
- * - 'latest': 최신 등록 순
+ * - '별점순': 별점 높은 순
+ * - '인기순': 인기 많은 순
+ * - '최신순': 최신 등록 순
  */
-export type SortOption = 'rating' | 'popular' | 'latest';
+export type SortOption = '별점순' | '인기순' | '최신순';
 
 /**
  * 여행 기간 타입
@@ -24,13 +24,9 @@ export type SortOption = 'rating' | 'popular' | 'latest';
 
 export type TripDays = 'ONE_DAY' | 'TWO_DAYS' | 'THREE_DAYS' | 'FOUR_DAYS' | 'FIVE_DAYS';
 /**
- * 정렬 옵션의 한글 표시 이름
+ * 정렬 옵션 목록
  */
-export const SORT_OPTIONS: Record<SortOption, string> = {
-  rating: '별점순',
-  popular: '인기순',
-  latest: '최신순',
-};
+export const SORT_OPTIONS_LIST: SortOption[] = ['별점순', '인기순', '최신순'];
 
 /**
  * 템플릿 탐색 API 요청 파라미터

--- a/src/feature/search/types/searchTemplate.types.ts
+++ b/src/feature/search/types/searchTemplate.types.ts
@@ -105,4 +105,15 @@ export interface FilterTag {
  * @remarks
  * - 서버 API 응답 페이로드입니다.
  */
-export type SearchTemplateResponseDTO = SuccessPayload<Template[]>;
+export interface PageResponse<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}
+
+export type SearchTemplateResponseDTO = SuccessPayload<PageResponse<Template>>;

--- a/src/feature/search/types/searchTemplate.types.ts
+++ b/src/feature/search/types/searchTemplate.types.ts
@@ -56,9 +56,6 @@ export interface SearchTemplateParams {
 
   /** 페이지 번호 (0부터 시작) */
   page?: number;
-
-  /** 페이지 크기 */
-  size?: number;
 }
 
 /**

--- a/src/feature/template/TemplateCard.tsx
+++ b/src/feature/template/TemplateCard.tsx
@@ -8,6 +8,7 @@ import type { Template } from '../home/types/template';
 import DefaultThumbnail from '@assets/template/thumbnail.png';
 import usePostTemplateRemix from '../home/hooks/mutations/usePostTemplateRemix';
 import { useNavigate } from 'react-router-dom';
+import { formatOneDecimal } from '@/shared/utils/format';
 
 // Props of TemplateCard
 interface TemplateCardProps {
@@ -92,7 +93,7 @@ const TemplateCard = ({ template, type, onButtonClick, onCardClick }: TemplateCa
                 <>
                   <span className={TemplateCardStyle.metadataItem}>
                     <StarIcon className={TemplateCardStyle.starIcon} />
-                    {template.avgRating}
+                    {formatOneDecimal(template.avgRating)}
                   </span>
                   <span className={TemplateCardStyle.metadataItem}>리믹스 {template.remixCount}회</span>
                 </>
@@ -101,7 +102,7 @@ const TemplateCard = ({ template, type, onButtonClick, onCardClick }: TemplateCa
 
             <SingleButton
               text={type === 'recommended' ? '이 템플릿 사용하기' : '리믹스 하기'}
-              width={387}
+              width="full"
               height={45}
               textSize={18}
               variant="white"

--- a/src/feature/template/TemplateSwiper.tsx
+++ b/src/feature/template/TemplateSwiper.tsx
@@ -12,7 +12,7 @@ interface TemplateSwiperProps {
 }
 
 const TemplateSwiper = ({ cards, type, onCardClick }: TemplateSwiperProps) => {
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(2);
   const [viewportWidth, setViewportWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/src/feature/template/styles/TemplateCard.styles.tsx
+++ b/src/feature/template/styles/TemplateCard.styles.tsx
@@ -4,7 +4,7 @@ export const TemplateCardStyle = {
   //Wrapper
   wrapper: (canHover: boolean = true) =>
     clsx(
-      'w-[387px] aspect-[387/455]',
+      'w-full aspect-[387/455]',
       'transition-transform duration-300 ease-in-out',
       canHover && 'hover:scale-[1.0336]', // 400/387 = 1.0336
     ),
@@ -16,7 +16,7 @@ export const TemplateCardStyle = {
       'w-full h-full',
       'rounded-[30px] overflow-hidden',
       'bg-white border ',
-      haveHoverGroup ? 'border-base-color-3' : 'border-base-color-6',
+      haveHoverGroup ? 'border-base-color-3' : 'border-base-color',
       'shadow-[0_1px_20px_0_rgba(0,0,0,0.15)]',
       'relative flex flex-col',
     ),

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -1,0 +1,16 @@
+/**
+ * 숫자를 소수점 첫째 자리까지 포맷팅합니다.
+ * (예: 4 -> "4.0", 4.5 -> "4.5", 4.56 -> "4.6")
+ *
+ * @param value - 포맷팅할 숫자
+ * @returns 소수점 첫째 자리까지 표시된 문자열
+ */
+export const formatOneDecimal = (value: number | string | undefined | null): string => {
+  if (value === undefined || value === null || value === '') return '0.0';
+
+  const num = typeof value === 'string' ? parseFloat(value) : value;
+
+  if (isNaN(num)) return '0.0';
+
+  return num.toFixed(1);
+};


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #124

### ✨️ 작업 내용
**1. 템플릿 탐색**
템플릿 탐색 api 명세가 변경되어 이에 맞춰 수정했습니다.
한 페이지에서 9개 이상의 카드가 보이는 문제를 수정했습니다.

**2. 홈 화면 카드 템플릿 섹션**
기본 스크롤 값을 2로 주었습니다. (사유: 스크롤 값 0일 시(제일 왼쪽 스크롤일 시) 왼쪽이 비어보이는 형태가 보기 좋지 않음)

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
### 템플릿 페이지네이션 수정 결과 화면 1
https://github.com/user-attachments/assets/ddec70e1-c3d4-42c9-8dd9-8d1349bf93a2
### 템플릿 페이지네이션 수정 결과 화면 2
https://github.com/user-attachments/assets/799ec4df-1d5e-49f1-bc82-bfcf16698d6b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프로필 이미지가 올바르게 표시되도록 개선
  * 빈 검색 결과 처리 개선(빈 페이징 응답 반환)

* **새로운 기능**
  * 페이지 네비게이션 개선: 마지막 페이지 처리 및 버튼 비활성화

* **사용성 개선**
  * 기본 정렬 옵션을 '별점순'으로 변경
  * 정렬 드롭다운을 한글 라벨 목록으로 단순화
  * 레이아웃을 3단에서 2단으로 최적화 및 카드/버튼 반응성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->