### PR TITLE
[Feat] 템플릿 경로 폴리곤 추가

### DIFF
--- a/src/feature/main_page/SideBar.tsx
+++ b/src/feature/main_page/SideBar.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import { useTemplateDetail } from './hooks/queries/useTemplateDetail';
+import { getTemplateDayRoutes } from './api/templateDetail.api';
 import usePostTemplateRemix from '@/feature/home/hooks/mutations/usePostTemplateRemix';
 import DefaultThumbnail from '@assets/template/thumbnail.png';
 import HeartIcon from '@assets/heart.svg?react';
@@ -16,6 +17,7 @@ import { toast } from '@/shared/stores/toastStore';
 import type { ResponseRemixDto } from '@/feature/home/types/template';
 import { motion, AnimatePresence } from 'motion/react';
 import { formatOneDecimal } from '@/shared/utils/format';
+import { toTripDayCount } from '@/shared/constants/tripDays';
 
 interface SideBarContentProps {
   templateId: number;
@@ -47,18 +49,83 @@ const SideBarContent = ({ templateId, onClose, isClosing }: SideBarContentProps)
   useEffect(() => {
     if (!mapRef.current || !window.kakao || !detail) return;
 
-    window.kakao.maps.load(() => {
-      const firstVlock = detail.vlocks?.[0];
-      const lat = firstVlock?.latitude ?? 35.1796;
-      const lng = firstVlock?.longitude ?? 129.0756;
+    let isDisposed = false;
+    let polyline: kakao.maps.Polyline | null = null;
 
-      const options = {
-        center: new window.kakao.maps.LatLng(lat, lng),
+    window.kakao.maps.load(() => {
+      if (isDisposed || !mapRef.current) return;
+
+      const map = new window.kakao.maps.Map(mapRef.current, {
+        center: new window.kakao.maps.LatLng(35.1796, 129.0756),
         level: 5,
+      });
+
+      const drawPolyline = (path: kakao.maps.LatLng[]) => {
+        if (path.length < 2) return;
+
+        polyline?.setMap(null);
+
+        polyline = new window.kakao.maps.Polyline({
+          map,
+          path,
+          strokeWeight: 4,
+          strokeColor: '#3388FF',
+          strokeOpacity: 0.9,
+          strokeStyle: 'solid',
+        });
+
+        const bounds = new window.kakao.maps.LatLngBounds();
+        path.forEach((latLng) => bounds.extend(latLng));
+        map.setBounds(bounds);
       };
-      new window.kakao.maps.Map(mapRef.current!, options);
+
+      const drawRoutePolyline = async () => {
+        const dayCount = toTripDayCount(detail.tripDays);
+        if (dayCount <= 0) return;
+
+        const dayNos = Array.from({ length: dayCount }, (_, idx) => idx + 1);
+
+        // 모든 day에 대한 route 정보를 병렬적으로 가져옴
+        const routeGroups = await Promise.all(
+          dayNos.map(async (dayNo) => {
+            try {
+              const response = await getTemplateDayRoutes(templateId, dayNo);
+              return response.data.routes;
+            } catch (error) {
+              console.error(error);
+              return [];
+            }
+          }),
+        );
+
+        if (isDisposed) return;
+
+        // 각 day의 route를 이어서 점들로 LatLng 생성
+        const routePath = routeGroups
+          .flat()
+          .flatMap((route) => route.polyline)
+          .filter(
+            (coordinate): coordinate is [number, number] =>
+              coordinate.length === 2 && Number.isFinite(coordinate[0]) && Number.isFinite(coordinate[1]),
+          )
+          .map(([lng, lat]) => new window.kakao.maps.LatLng(lat, lng));
+
+        if (routePath.length === 1) {
+          map.setCenter(routePath[0]);
+          return;
+        }
+
+        drawPolyline(routePath);
+      };
+
+      void drawRoutePolyline();
     });
-  }, [detail]);
+
+    return () => {
+      isDisposed = true;
+      polyline?.setMap(null);
+    };
+  }, [detail, templateId]);
 
   const handleHeartClick = () => {
     const nextState = !isLiked;

--- a/src/feature/main_page/SideBar.tsx
+++ b/src/feature/main_page/SideBar.tsx
@@ -51,6 +51,7 @@ const SideBarContent = ({ templateId, onClose, isClosing }: SideBarContentProps)
 
     let isDisposed = false;
     let polyline: kakao.maps.Polyline | null = null;
+    const markers: kakao.maps.Marker[] = [];
 
     window.kakao.maps.load(() => {
       if (isDisposed || !mapRef.current) return;
@@ -58,6 +59,19 @@ const SideBarContent = ({ templateId, onClose, isClosing }: SideBarContentProps)
       const map = new window.kakao.maps.Map(mapRef.current, {
         center: new window.kakao.maps.LatLng(35.1796, 129.0756),
         level: 5,
+      });
+
+      const markerPositions = detail.vlocks
+        .filter((vlock) => Number.isFinite(vlock.latitude) && Number.isFinite(vlock.longitude))
+        .map((vlock) => new window.kakao.maps.LatLng(vlock.latitude, vlock.longitude));
+
+      markerPositions.forEach((position) => {
+        markers.push(
+          new window.kakao.maps.Marker({
+            map,
+            position,
+          }),
+        );
       });
 
       const drawPolyline = (path: kakao.maps.LatLng[]) => {
@@ -110,10 +124,7 @@ const SideBarContent = ({ templateId, onClose, isClosing }: SideBarContentProps)
           )
           .map(([lng, lat]) => new window.kakao.maps.LatLng(lat, lng));
 
-        if (routePath.length === 1) {
-          map.setCenter(routePath[0]);
-          return;
-        }
+        if (routePath.length < 2) return;
 
         drawPolyline(routePath);
       };
@@ -124,6 +135,7 @@ const SideBarContent = ({ templateId, onClose, isClosing }: SideBarContentProps)
     return () => {
       isDisposed = true;
       polyline?.setMap(null);
+      markers.forEach((marker) => marker.setMap(null));
     };
   }, [detail, templateId]);
 

--- a/src/feature/main_page/api/templateDetail.api.ts
+++ b/src/feature/main_page/api/templateDetail.api.ts
@@ -1,5 +1,5 @@
 import { axiosInstance } from '@/shared/apis/axios';
-import type { TemplateDetailResponseDTO } from '../types/templateDetail.types';
+import type { TemplateDayRoutesResponseDTO, TemplateDetailResponseDTO } from '../types/templateDetail.types';
 
 /**
  * 템플릿 상세 정보 조회 API 호출
@@ -7,6 +7,18 @@ import type { TemplateDetailResponseDTO } from '../types/templateDetail.types';
  */
 export async function getTemplateDetail(templateId: number): Promise<TemplateDetailResponseDTO> {
   const { data } = await axiosInstance.get<TemplateDetailResponseDTO>(`/templates/${templateId}`);
+  return data;
+}
+
+/**
+ * 템플릿 특정 day 경로 정보 조회 API 호출
+ * @param templateId 템플릿 ID
+ * @param dayNo day 번호 (1-based)
+ */
+export async function getTemplateDayRoutes(templateId: number, dayNo: number): Promise<TemplateDayRoutesResponseDTO> {
+  const { data } = await axiosInstance.get<TemplateDayRoutesResponseDTO>(
+    `/templates/${templateId}/days/${dayNo}/routes`,
+  );
   return data;
 }
 /**

--- a/src/feature/main_page/types/templateDetail.types.ts
+++ b/src/feature/main_page/types/templateDetail.types.ts
@@ -8,6 +8,22 @@ export interface VlockDetailDTO {
   address: string;
 }
 
+export type TemplateRouteTransportType = 'WALK' | 'CAR' | 'TRANSIT';
+
+export interface TemplateDayRouteDTO {
+  moveTimeId: number | null;
+  fromVlockId: number;
+  toVlockId: number;
+  moveMinutes: number;
+  distanceMeter: number;
+  transportType: TemplateRouteTransportType;
+  polyline: number[][];
+}
+
+export interface TemplateDayRoutesDTO {
+  routes: TemplateDayRouteDTO[];
+}
+
 export interface TemplateDetailDTO {
   templateId: number;
   title: string;
@@ -27,3 +43,4 @@ export interface TemplateDetailDTO {
 }
 
 export type TemplateDetailResponseDTO = SuccessPayload<TemplateDetailDTO>;
+export type TemplateDayRoutesResponseDTO = SuccessPayload<TemplateDayRoutesDTO>;

--- a/src/shared/types/kakao.d.ts
+++ b/src/shared/types/kakao.d.ts
@@ -46,6 +46,17 @@ declare namespace kakao.maps {
     endArrow?: boolean;
   }
 
+  class Marker {
+    constructor(options: MarkerOptions);
+    setMap(map: Map | null): void;
+  }
+
+  interface MarkerOptions {
+    map?: Map;
+    position: LatLng;
+    title?: string;
+  }
+
   function load(callback: () => void): void;
 
   namespace services {

--- a/src/shared/types/kakao.d.ts
+++ b/src/shared/types/kakao.d.ts
@@ -5,17 +5,45 @@ declare namespace kakao.maps {
     getLng(): number;
   }
 
+  class LatLngBounds {
+    constructor(sw?: LatLng, ne?: LatLng);
+    extend(latlng: LatLng): void;
+  }
+
   class Map {
     constructor(container: HTMLElement, options: MapOptions);
     setCenter(latlng: LatLng): void;
     setLevel(level: number): void;
     getCenter(): LatLng;
     getLevel(): number;
+    setBounds(
+      bounds: LatLngBounds,
+      paddingTop?: number,
+      paddingRight?: number,
+      paddingBottom?: number,
+      paddingLeft?: number,
+    ): void;
   }
 
   interface MapOptions {
     center: LatLng;
     level?: number;
+  }
+
+  class Polyline {
+    constructor(options: PolylineOptions);
+    setMap(map: Map | null): void;
+  }
+
+  interface PolylineOptions {
+    map?: Map;
+    path: LatLng[] | LatLng[][];
+    strokeWeight?: number;
+    strokeColor?: string;
+    strokeOpacity?: number;
+    strokeStyle?: string;
+    zIndex?: number;
+    endArrow?: boolean;
   }
 
   function load(callback: () => void): void;


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #72 

### ✨️ 작업 내용

템플릿 경로 폴리곤 추가

### 💭 코멘트

- 비어있는 템플릿은 카카오맵 기본 중앙으로 폴백됩니다

### 📸 구현 결과

<img width="758" height="625" alt="image" src="https://github.com/user-attachments/assets/fb47d33d-9ced-462e-9be4-ca12264708a9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 지도에 여행 경로 시각화 기능을 추가했습니다. 방문 장소는 마커로 표시되며, 이동 경로는 폴리라인으로 시각적으로 표현됩니다. 일별 경로 정보를 동적으로 로드하여 전체 여행 일정을 지도상에 통합 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->