### PR TITLE
[Fix] QA 1차

### DIFF
--- a/src/feature/block/blockBuild/blockBuild.type.ts
+++ b/src/feature/block/blockBuild/blockBuild.type.ts
@@ -132,6 +132,7 @@ export type CanvasVlockBrief = {
   vlockId: number;
   name: string;
   category: string;
+  coverImgUrl?: string;
 };
 
 export type CanvasVlockData = {

--- a/src/feature/block/blockBuild/components/BlockEditor.tsx
+++ b/src/feature/block/blockBuild/components/BlockEditor.tsx
@@ -9,14 +9,15 @@ import PuzzleBlock from './ui/PuzzleBlock';
 import BlockTimeLine from '../../blockTimeLine/BlockTimeLine';
 import BlockItemUI from '@/shared/components/Block/BlockItemUI';
 import type { Level } from '../types/level';
-import { type SetStateAction, useRef, useState } from 'react';
+import { type SetStateAction, useMemo, useRef, useState } from 'react';
 import { useBlockUndoRedo } from '../hooks/useBlockUndoRedo';
 import { getDescendantBlocks, getDescendants } from '../utils/path';
 import VlockModal from '@/feature/block/vlockModal/VlockModal';
 import type { VlockData, VlockModalRequestDto } from '@/feature/block/vlockModal/types/vlockModal.types';
-import type { SidebarBlock, CategoryType } from '../types/block';
+import type { CategoryType, SidebarBlock } from '../types/block';
 import { VLOCK_CATEGORY_MAP } from '@/shared/constants/vlockCategory';
 import { MOCK_BLOCKS } from '../mock';
+import { deriveConnectedConnectorEdgeMap } from '../utils/connectedConnectorEdges';
 
 interface BlockEditorProps {
   level: Level;
@@ -36,6 +37,7 @@ const mapVlockToSidebarBlock = (vlock: VlockData): SidebarBlock => {
 
 const BlockEditor = ({ level, setLevel, onSummaryUpdatingChange }: BlockEditorProps) => {
   const { puzzleBlocks, currentDay, tripDays, actions: editorActions } = useBlockEditor();
+  const connectedEdgeMap = useMemo(() => deriveConnectedConnectorEdgeMap(puzzleBlocks), [puzzleBlocks]);
   const [zoom, setZoom] = useState(1);
   const [blockItems, setBlockItems] = useState<SidebarBlock[]>(MOCK_BLOCKS);
   const [activeVlockModal, setActiveVlockModal] = useState<{
@@ -158,7 +160,12 @@ const BlockEditor = ({ level, setLevel, onSummaryUpdatingChange }: BlockEditorPr
                       transform: `scale(${zoom})`,
                       transformOrigin: 'top left',
                     }}>
-                    <PuzzleBlock block={b} isOverlay />
+                    <PuzzleBlock
+                      block={b}
+                      connectedPlugEdgeIndex={connectedEdgeMap.get(b.blockId)?.connectedPlugEdgeIndex ?? null}
+                      connectedSocketEdgeIndex={connectedEdgeMap.get(b.blockId)?.connectedSocketEdgeIndex ?? null}
+                      isOverlay
+                    />
                   </div>
                 ))}
               </div>

--- a/src/feature/block/blockBuild/components/main/BlockEditorContent.tsx
+++ b/src/feature/block/blockBuild/components/main/BlockEditorContent.tsx
@@ -1,5 +1,5 @@
 import { useDroppable } from '@dnd-kit/core';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import clsx from 'clsx';
 import { IconBase } from '@/shared/ui/icon/IconBase';
 import TriangleIcon from '@feature/block/blockBuild/assets/edit-icon-triangle.svg?react';
@@ -13,6 +13,7 @@ import BlockStartNode from '../ui/BlockStartNode';
 import BlockUndoRedo from './BlockUndoRedo';
 import { useCanvasPanZoom } from '@/shared/hooks/useCanvasPanZoom';
 import BlockTrash from './BlockTrash';
+import { deriveConnectedConnectorEdgeMap } from '../../utils/connectedConnectorEdges';
 
 const CANVAS_W = 1680;
 const CANVAS_H = 2600;
@@ -72,6 +73,7 @@ const BlockEditorContent = ({
   const hasAvailableDays = maxDay > 0;
   const isPrevDisabled = !hasAvailableDays || currentDay <= 1;
   const isNextDisabled = !hasAvailableDays || currentDay >= maxDay;
+  const connectedEdgeMap = useMemo(() => deriveConnectedConnectorEdgeMap(puzzleBlocks), [puzzleBlocks]);
 
   // 날짜 변경 핸들러
   const handleDayChange = (day: number) => {
@@ -159,7 +161,18 @@ const BlockEditorContent = ({
                   }
                   // 드래그 중인 블록과 자손들은 숨김 (DOM에서 유지하여 위치 점프 방지)
                   const isHidden = draggingBlockIds.includes(block.blockId);
-                  return <PuzzleBlock key={block.blockId} block={block} canDrag isHidden={isHidden} />;
+                  const connectedEdges = connectedEdgeMap.get(block.blockId);
+
+                  return (
+                    <PuzzleBlock
+                      key={block.blockId}
+                      block={block}
+                      connectedPlugEdgeIndex={connectedEdges?.connectedPlugEdgeIndex ?? null}
+                      connectedSocketEdgeIndex={connectedEdges?.connectedSocketEdgeIndex ?? null}
+                      canDrag
+                      isHidden={isHidden}
+                    />
+                  );
                 })}
 
                 <BlockGhost hint={dockHint} />

--- a/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
+++ b/src/feature/block/blockBuild/components/ui/PuzzleBlock.tsx
@@ -4,6 +4,8 @@ import { Block } from '@/shared/components/Block/Block';
 
 interface PuzzleBlockProps {
   block: BlockData;
+  connectedPlugEdgeIndex?: number | null;
+  connectedSocketEdgeIndex?: number | null;
   canDrag?: boolean;
   isOverlay?: boolean;
   /** 상위 블록이 드래그될 때 true - DragOverlay에서 서브트리로 표시되므로 원본은 숨김 */
@@ -13,6 +15,8 @@ interface PuzzleBlockProps {
 
 export default function PuzzleBlock({
   block,
+  connectedPlugEdgeIndex = null,
+  connectedSocketEdgeIndex = null,
   canDrag = false,
   isOverlay = false,
   isHidden = false,
@@ -43,6 +47,8 @@ export default function PuzzleBlock({
           duration={block.duration}
           points={block.points}
           connections={block.connectors}
+          connectedPlugEdgeIndex={connectedPlugEdgeIndex}
+          connectedSocketEdgeIndex={connectedSocketEdgeIndex}
           color={block.color}
           style={{ transform: `scale(${zoom})`, transformOrigin: 'top left' }}
         />
@@ -75,6 +81,8 @@ export default function PuzzleBlock({
         duration={block.duration}
         points={block.points}
         connections={block.connectors}
+        connectedPlugEdgeIndex={connectedPlugEdgeIndex}
+        connectedSocketEdgeIndex={connectedSocketEdgeIndex}
         color={block.color}
       />
     </div>

--- a/src/feature/block/blockBuild/hooks/useBlockSync.ts
+++ b/src/feature/block/blockBuild/hooks/useBlockSync.ts
@@ -80,6 +80,27 @@ export const useBlockSync = ({ onSummaryUpdatingChange, isSyncPausedRef }: UseBl
     return isSyncPausedRef?.current === true;
   }, [isSyncPausedRef]);
 
+  const preserveMissingImageUrls = useCallback((nextBlocks: Block[], prevBlocks: Block[]): Block[] => {
+    const prevImageByBlockId = new Map<number, string>();
+
+    for (const block of prevBlocks) {
+      if (typeof block.imageUrl === 'string' && block.imageUrl.trim().length > 0) {
+        prevImageByBlockId.set(block.blockId, block.imageUrl);
+      }
+    }
+
+    if (prevImageByBlockId.size === 0) return nextBlocks;
+
+    return nextBlocks.map((block) => {
+      if (typeof block.imageUrl === 'string' && block.imageUrl.trim().length > 0) {
+        return block;
+      }
+
+      const preservedImageUrl = prevImageByBlockId.get(block.blockId);
+      return preservedImageUrl ? { ...block, imageUrl: preservedImageUrl } : block;
+    });
+  }, []);
+
   const withSuppressedSync = useCallback(
     (updater: (prev: Record<number, Block[]>) => Record<number, Block[]>) => {
       suppressSyncRef.current = true;
@@ -118,12 +139,14 @@ export const useBlockSync = ({ onSummaryUpdatingChange, isSyncPausedRef }: UseBl
         setTripDays(response.data.tripDays);
 
         const mapped = mapCanvasToBlocksFallback(response.data);
-        latestBlocksByDayRef.current[day] = mapped;
-        syncedBlocksByDayRef.current[day] = mapped;
+        const prevBlocksForDay = latestBlocksByDayRef.current[day] ?? blocksByDayRef.current[day] ?? [];
+        const hydrated = preserveMissingImageUrls(mapped, prevBlocksForDay);
+        latestBlocksByDayRef.current[day] = hydrated;
+        syncedBlocksByDayRef.current[day] = hydrated;
 
         withSuppressedSync((prev) => ({
           ...prev,
-          [day]: mapped,
+          [day]: hydrated,
         }));
 
         if (shouldInvalidateSummary) {
@@ -148,6 +171,7 @@ export const useBlockSync = ({ onSummaryUpdatingChange, isSyncPausedRef }: UseBl
       setTripDays,
       invalidateBlockSummary,
       setSyncStatus,
+      preserveMissingImageUrls,
     ],
   );
 

--- a/src/feature/block/blockBuild/utils/canvasFallbackMapper.ts
+++ b/src/feature/block/blockBuild/utils/canvasFallbackMapper.ts
@@ -98,7 +98,7 @@ const createMappedBlock = (vlock: CanvasVlockData, dayNo: number): Block => {
     name: vlock.vlock.name,
     category,
     duration,
-    imageUrl: undefined,
+    imageUrl: vlock.vlock.coverImgUrl,
     color: categoryColor[category],
     x: initial.x,
     y: initial.y,

--- a/src/feature/block/blockBuild/utils/connectedConnectorEdges.ts
+++ b/src/feature/block/blockBuild/utils/connectedConnectorEdges.ts
@@ -1,0 +1,99 @@
+import { getConnectorCenter, type Connector, type Point } from '@/shared/components/Block/blockShape';
+import type { Block } from '../types/block';
+
+const TAB_WIDTH = 42;
+
+export type ConnectedConnectorEdges = {
+  connectedPlugEdgeIndex: number | null;
+  connectedSocketEdgeIndex: number | null;
+};
+
+const distance = (a: Point, b: Point): number => {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+};
+
+const toAbsoluteCenter = (block: Block, connector: Connector): Point | null => {
+  const local = getConnectorCenter(block.points, connector, TAB_WIDTH);
+  if (!local) return null;
+
+  return {
+    x: block.x + local.x,
+    y: block.y + local.y,
+  };
+};
+
+const pickBestConnectorPair = (parent: Block, child: Block) => {
+  const sockets = parent.connectors.filter((connector) => connector.type === 'socket');
+  const plugs = child.connectors.filter((connector) => connector.type === 'plug');
+
+  let best:
+    | {
+        socket: Connector;
+        plug: Connector;
+        dist: number;
+      }
+    | undefined;
+
+  for (const socket of sockets) {
+    const socketAbs = toAbsoluteCenter(parent, socket);
+    if (!socketAbs) continue;
+
+    for (const plug of plugs) {
+      const plugAbs = toAbsoluteCenter(child, plug);
+      if (!plugAbs) continue;
+
+      const d = distance(socketAbs, plugAbs);
+      if (!best || d < best.dist) {
+        best = { socket, plug, dist: d };
+      }
+    }
+  }
+
+  if (!best) return undefined;
+  return { socket: best.socket, plug: best.plug };
+};
+
+/**
+ * 블록이 다른 블록과 어떤 connector와 연결되어 있는지를 반환
+ * @param blocks
+ * @returns 각 블록이 실제로 연결돼있는 connector의 edgeIndex
+ */
+export const deriveConnectedConnectorEdgeMap = (blocks: Block[]): Map<number, ConnectedConnectorEdges> => {
+  const byId = new Map(blocks.map((block) => [block.blockId, block]));
+  const edgeMap = new Map<number, ConnectedConnectorEdges>();
+
+  for (const block of blocks) {
+    edgeMap.set(block.blockId, {
+      connectedPlugEdgeIndex: null,
+      connectedSocketEdgeIndex: null,
+    });
+  }
+
+  for (const parent of blocks) {
+    if (parent.connectedTo == null) continue;
+
+    const child = byId.get(parent.connectedTo);
+    if (!child) continue;
+
+    const pair = pickBestConnectorPair(parent, child);
+    if (!pair) continue;
+
+    const parentState = edgeMap.get(parent.blockId) ?? {
+      connectedPlugEdgeIndex: null,
+      connectedSocketEdgeIndex: null,
+    };
+    parentState.connectedSocketEdgeIndex = pair.socket.edgeIndex;
+    edgeMap.set(parent.blockId, parentState);
+
+    const childState = edgeMap.get(child.blockId) ?? {
+      connectedPlugEdgeIndex: null,
+      connectedSocketEdgeIndex: null,
+    };
+    childState.connectedPlugEdgeIndex = pair.plug.edgeIndex;
+    edgeMap.set(child.blockId, childState);
+  }
+
+  return edgeMap;
+};

--- a/src/feature/block/blockHeader/components/SaveModal.tsx
+++ b/src/feature/block/blockHeader/components/SaveModal.tsx
@@ -9,6 +9,8 @@ import Input from '@/shared/components/Form/Input';
 import SingleButton from '@/shared/components/Button/SingleButton';
 import type { RequestSaveTemplateDto } from '../types/template';
 import usePatchSaveTemplate from '../hooks/mutations/usePatchSaveTemplate';
+import { toast } from '@/shared/stores/toastStore';
+import { extractErrorMessage } from '@/shared/utils/apiErrorHandler';
 
 interface SaveModalProps {
   selectedId: number;
@@ -18,13 +20,15 @@ interface SaveModalProps {
 
 const SaveModal = ({ selectedId, setSelectedId, setShowSaveModal }: SaveModalProps) => {
   const { register, control, handleSubmit } = useFormContext<FormFields>();
-  const { mutate } = usePatchSaveTemplate();
+  const { mutate, isPending } = usePatchSaveTemplate();
 
   const { templateId } = useParams();
   const navigate = useNavigate();
   const [cover, setCover] = useState<File | null>(null);
 
   const onSubmit = (data: FormFields) => {
+    if (isPending) return;
+
     const body: RequestSaveTemplateDto = {
       title: data.title,
       description: data.description,
@@ -36,8 +40,12 @@ const SaveModal = ({ selectedId, setSelectedId, setShowSaveModal }: SaveModalPro
       { templateId: Number(templateId), body },
       {
         onSuccess: (data) => {
+          toast.success('템플릿이 저장되었습니다.', 'bottom-center');
           setShowSaveModal(false);
           navigate(`/block/${data.data.templateId}`);
+        },
+        onError: (error) => {
+          toast.error(extractErrorMessage(error, '템플릿 저장에 실패했습니다.'), 'bottom-center');
         },
       },
     );
@@ -111,7 +119,14 @@ const SaveModal = ({ selectedId, setSelectedId, setShowSaveModal }: SaveModalPro
 
         <div className="flex gap-[20px]">
           <SingleButton text="취소" width={107} height={64} variant="white" onClick={() => setShowSaveModal(false)} />
-          <SingleButton text="저장" width={327} height={64} variant="primary" onClick={handleSubmit(onSubmit)} />
+          <SingleButton
+            text={isPending ? '저장 중...' : '저장'}
+            width={327}
+            height={64}
+            variant="primary"
+            disabled={isPending}
+            onClick={handleSubmit(onSubmit)}
+          />
         </div>
       </div>
     </div>

--- a/src/feature/block/blockSummary/BlockSummary.tsx
+++ b/src/feature/block/blockSummary/BlockSummary.tsx
@@ -34,7 +34,7 @@ const BlockSummary = ({ isSyncUpdating = false }: BlockSummaryProps) => {
       const response = await getTemplateSummary(templateIdNum);
       const summary = response.data;
       const totalMoveMinutes = Math.max(0, Math.round(summary.totalMoveMinutes));
-      const totalDurationMinutes = toMinutes(summary.totalStayHours) + totalMoveMinutes;
+      const totalDurationMinutes = toMinutes(summary.totalStayHours);
 
       return {
         totalVlocks: summary.totalVlocks,

--- a/src/feature/mypage/components/SettingsSection.tsx
+++ b/src/feature/mypage/components/SettingsSection.tsx
@@ -4,6 +4,7 @@ import SectionHeader from './SectionHeader';
 import ProfileEditForm from './ProfileEditForm';
 import TravelStyleSection, { type TravelStyle } from './TravelStyleSection';
 import InterestThemeSection, { type InterestTheme } from './InterestThemeSection';
+import { toast } from '@/shared/stores/toastStore';
 
 interface SettingsSectionProps {
   initialNickname?: string;
@@ -22,6 +23,7 @@ interface SettingsSectionProps {
 }
 
 const MAX_SELECTABLE_PREFERENCES = 2;
+const MAX_SELECTABLE_PREFERENCES_TOAST = '최대 2개까지 선택할 수 있습니다.';
 
 const SettingsSection = ({
   initialNickname = '',
@@ -39,6 +41,11 @@ const SettingsSection = ({
   const [interestThemes, setInterestThemes] = useState<InterestTheme[]>(initialInterestThemes);
 
   const handleToggleTravelStyle = (style: TravelStyle) => {
+    if (!travelStyles.includes(style) && travelStyles.length >= MAX_SELECTABLE_PREFERENCES) {
+      toast.error(MAX_SELECTABLE_PREFERENCES_TOAST, 'bottom-center');
+      return;
+    }
+
     setTravelStyles((prev) => {
       if (prev.includes(style)) {
         return prev.filter((s) => s !== style);
@@ -53,6 +60,11 @@ const SettingsSection = ({
   };
 
   const handleToggleInterestTheme = (theme: InterestTheme) => {
+    if (!interestThemes.includes(theme) && interestThemes.length >= MAX_SELECTABLE_PREFERENCES) {
+      toast.error(MAX_SELECTABLE_PREFERENCES_TOAST, 'bottom-center');
+      return;
+    }
+
     setInterestThemes((prev) => {
       if (prev.includes(theme)) {
         return prev.filter((t) => t !== theme);

--- a/src/shared/components/Block/Block.tsx
+++ b/src/shared/components/Block/Block.tsx
@@ -14,6 +14,8 @@ interface BlockProps {
   color?: string;
   className?: string;
   connections?: Connector[];
+  connectedPlugEdgeIndex?: number | null;
+  connectedSocketEdgeIndex?: number | null;
   points: Point[];
   style?: React.CSSProperties;
 }
@@ -26,6 +28,8 @@ export const Block = ({
   color = 'text-negative',
   className,
   connections = [],
+  connectedPlugEdgeIndex = null,
+  connectedSocketEdgeIndex = null,
   points,
   style,
 }: BlockProps) => {
@@ -52,7 +56,25 @@ export const Block = ({
     };
   }, [points]);
 
-  const pathD = useBlockPath(points, connections);
+  // connected edge가 확정된 타입만 해당 edge를 남기고 나머지를 숨김
+  const visibleConnections = useMemo(() => {
+    const plugs = connections.filter((connector) => connector.type === 'plug');
+    const sockets = connections.filter((connector) => connector.type === 'socket');
+
+    return connections.filter((connector) => {
+      if (connector.type === 'plug' && plugs.length > 1 && connectedPlugEdgeIndex != null) {
+        return connector.edgeIndex === connectedPlugEdgeIndex;
+      }
+
+      if (connector.type === 'socket' && sockets.length > 1 && connectedSocketEdgeIndex != null) {
+        return connector.edgeIndex === connectedSocketEdgeIndex;
+      }
+
+      return true;
+    });
+  }, [connections, connectedPlugEdgeIndex, connectedSocketEdgeIndex]);
+
+  const pathD = useBlockPath(points, visibleConnections);
 
   return (
     <div className={`relative ${className}`} style={{ width: totalWidth, height: totalHeight, ...style }}>


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #130 

### ✨️ 작업 내용

QA 1차 작업
- 블록이 연결되어 있으면 다른 연결부 막기
- 마이페이지 관심 테마/여행 스타일에서 2개 이상 선택된 상태에서 더 선택하려고 하면 alert 띄우기
- 템플릿 블록을 캔버스에 추가하고 새로고침 하면 커버 이미지가 사라지는 이슈
- 템플릿 다이얼로그 안의 저장 버튼의 토스트 피드백
- 일정 요약의 총 소요 시간에는 이동 시간을 포함시키지 않아야 함


### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

| <img width="571" height="455" alt="image" src="https://github.com/user-attachments/assets/e49184b6-5751-4fd0-b677-15f636f09aa2" /> | <img width="1469" height="945" alt="image" src="https://github.com/user-attachments/assets/4b03988c-1fe4-41e0-afae-d467d5ca8c45" /> |
| --- | --- |
| <img width="568" height="807" alt="image" src="https://github.com/user-attachments/assets/cb107686-a7de-4485-9623-cdb19f420d16" /> |  |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 블록 연결 시각화 개선으로 더 정확한 커넥션 표시
  * 저장 중 로딩 상태 표시 및 에러 메시지 개선
  * 설정 선택 항목에 개수 제한 안내 (최대 2개) 추가

* **Bug Fixes**
  * 동기화 중 이미지 URL 손실 방지
  * 블록 커버 이미지 URL 매핑 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->