### PR TITLE
[Feat] 즐겨찾기 템플릿 목록 필터 추가

### DIFF
--- a/src/feature/mypage/apis/mypage.ts
+++ b/src/feature/mypage/apis/mypage.ts
@@ -39,6 +39,18 @@ export const getMyTemplates = async (page = 0): Promise<ResponseMyTemplatesDto> 
   }
 };
 
+export const getMyFavoriteTemplates = async (page = 0): Promise<ResponseMyTemplatesDto> => {
+  try {
+    const { data } = await axiosInstance.get<ResponseMyTemplatesDto>('/members/me/favorites', {
+      params: { page },
+    });
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
 export const getMemberProfile = async (memberId: number, page = 0): Promise<ResponseMemberProfileDto> => {
   try {
     const { data } = await axiosInstance.get<ResponseMemberProfileDto>(`/members/${memberId}/profile`, {

--- a/src/feature/mypage/components/Dashboard.tsx
+++ b/src/feature/mypage/components/Dashboard.tsx
@@ -171,7 +171,7 @@ const Dashboard = () => {
           icon={<StarIcon />}
           label="즐겨찾기"
           count={myPageData.counts.starCount}
-          onClick={() => navigate('/mypage/templates')}
+          onClick={() => navigate('/mypage/templates?filter=favorite')}
         />
       </div>
 

--- a/src/feature/mypage/hooks/useMyTemplatesQuery.ts
+++ b/src/feature/mypage/hooks/useMyTemplatesQuery.ts
@@ -1,13 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
-import { getMyTemplates } from '../apis/mypage';
+import { getMyFavoriteTemplates, getMyTemplates } from '../apis/mypage';
 import type { TemplateCardDto } from '../types/mypage.type';
 import type { PageResponse } from '@/shared/types/pagination';
 
-export const useMyTemplatesQuery = (page = 0) => {
+export type MyTemplateFilter = 'created' | 'favorite';
+
+export const useMyTemplatesQuery = (page = 0, filter: MyTemplateFilter = 'created') => {
   return useQuery<PageResponse<TemplateCardDto>>({
-    queryKey: ['my-templates', page],
+    queryKey: ['my-templates', filter, page],
     queryFn: async () => {
-      const response = await getMyTemplates(page);
+      const response = filter === 'favorite' ? await getMyFavoriteTemplates(page) : await getMyTemplates(page);
       return response.data;
     },
   });

--- a/src/pages/MyPage/TemplatesPage.tsx
+++ b/src/pages/MyPage/TemplatesPage.tsx
@@ -1,16 +1,27 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useMyPageQuery } from '@/feature/mypage/hooks/useMyPageQuery';
-import { useMyTemplatesQuery } from '@/feature/mypage/hooks/useMyTemplatesQuery';
+import { type MyTemplateFilter, useMyTemplatesQuery } from '@/feature/mypage/hooks/useMyTemplatesQuery';
 import TemplateCard from '@/feature/template/TemplateCard';
 import ProfileLayout from '@/feature/mypage/components/ProfileLayout';
 import { toTemplateCard } from '@/feature/mypage/utils/templateAdapter';
 import SideBar from '@/feature/main_page/SideBar';
 
+const parseFilter = (value: string | null): MyTemplateFilter => {
+  if (value === 'favorite') {
+    return 'favorite';
+  }
+  return 'created';
+};
+
 const TemplatesPage = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(null);
+  const [searchParams] = useSearchParams();
+  const filter = parseFilter(searchParams.get('filter'));
+  const isFavoriteFilter = filter === 'favorite';
   const { data: myPageData, isLoading: isProfileLoading, isError: isProfileError } = useMyPageQuery();
-  const { data: templateData, isLoading: isTemplateLoading, isError: isTemplateError } = useMyTemplatesQuery(0);
+  const { data: templateData, isLoading: isTemplateLoading, isError: isTemplateError } = useMyTemplatesQuery(0, filter);
 
   const templates = (templateData?.content ?? []).map(toTemplateCard);
 
@@ -33,8 +44,12 @@ const TemplatesPage = () => {
         nickname={myPageData.nickname}
         introduction={myPageData.introduction}
         profileImageUrl={myPageData.profileImageUrl}
-        title={`${myPageData.nickname}님이 만든 템플릿`}
-        description={`${myPageData.nickname}님이 만든 템플릿 목록입니다.`}
+        title={isFavoriteFilter ? `${myPageData.nickname}님이 저장한 템플릿` : `${myPageData.nickname}님이 만든 템플릿`}
+        description={
+          isFavoriteFilter
+            ? `${myPageData.nickname}님이 즐겨찾기한 템플릿 목록입니다.`
+            : `${myPageData.nickname}님이 만든 템플릿 목록입니다.`
+        }
         children={
           templates.length > 0 ? (
             <div className="grid grid-cols-1 gap-x-[18px] gap-y-[40px] sm:grid-cols-2 lg:grid-cols-3">
@@ -49,7 +64,9 @@ const TemplatesPage = () => {
               ))}
             </div>
           ) : (
-            <p className="text-center text-lg text-base-color-1">등록된 템플릿이 없습니다.</p>
+            <p className="text-center text-lg text-base-color-1">
+              {isFavoriteFilter ? '즐겨찾기한 템플릿이 없습니다.' : '등록된 템플릿이 없습니다.'}
+            </p>
           )
         }
       />


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #144 

### ✨️ 작업 내용

즐겨찾기 템플릿 목록 필터 추가

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 즐겨찾기한 템플릿을 별도로 조회할 수 있는 기능이 추가되었습니다.
* 마이페이지의 즐겨찾기 카드에서 즐겨찾기한 템플릿 목록으로 쉽게 이동할 수 있습니다.
* 생성한 템플릿과 즐겨찾기한 템플릿을 각각 관리 및 필터링할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->